### PR TITLE
Rename test utility performers

### DIFF
--- a/packages/lauf-example-async/src/index.tsx
+++ b/packages/lauf-example-async/src/index.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import { performSequence } from "@lauf/lauf-runner";
+import { launchSequence } from "@lauf/lauf-runner";
 import { mainPlan, createStore } from "./plans";
 import { App } from "./containers/App";
 
 const store = createStore();
-performSequence(mainPlan(store));
+launchSequence(mainPlan(store));
 ReactDOM.render(<App store={store} />, document.getElementById("root"));

--- a/packages/lauf-example-async/src/plans.ts
+++ b/packages/lauf-example-async/src/plans.ts
@@ -1,13 +1,16 @@
 import { Store, BasicStore, Selector } from "@lauf/lauf-store";
 import { Immutable } from "@lauf/lauf-store/types/immutable";
-import { editValue, followStoreSelector } from "@lauf/lauf-store-runner";
+import {
+  editValue,
+  followStoreSelector,
+  CONTINUE,
+} from "@lauf/lauf-store-runner";
 import {
   Action,
   ActionSequence,
   planOfAction,
-  performSequence,
+  launchSequence,
 } from "@lauf/lauf-runner";
-import { CONTINUE } from "@lauf/lauf-store-runner/types";
 
 /** STORE DEFINITIONS */
 
@@ -134,9 +137,9 @@ function* fetchFocusedPlan(store: Store<AppState>) {
 /** USER INPUTS */
 
 export function triggerSetFocus(store: Store<AppState>, focus: SubredditName) {
-  performSequence(setFocusPlan(store, focus));
+  launchSequence(setFocusPlan(store, focus));
 }
 
 export function triggerFetchFocused(store: Store<AppState>) {
-  performSequence(fetchFocusedPlan(store));
+  launchSequence(fetchFocusedPlan(store));
 }

--- a/packages/lauf-runner/src/core/util.ts
+++ b/packages/lauf-runner/src/core/util.ts
@@ -36,20 +36,20 @@ export function planOfAction<Params extends any[], Reaction = any>(
   };
 }
 
-export async function performPlan<Ending, Reaction>(
+export async function launchPlan<Ending, Reaction>(
   plan: ActionPlan<[], Ending, Reaction>
 ): Promise<Ending> {
-  const ending = await directPlan(plan, actor);
+  const ending = await performPlan(plan, actor);
   if (isTermination(ending)) {
     throw `Performer with Exit:never shouldn't terminate`;
   }
   return ending;
 }
 
-export async function performSequence<Ending, Reaction>(
+export async function launchSequence<Ending, Reaction>(
   sequence: ActionSequence<Ending, Reaction>
 ): Promise<Ending> {
-  const ending = await directSequence(sequence, actor);
+  const ending = await performSequence(sequence, actor);
   if (isTermination(ending)) {
     throw `Performer with Exit:never shouldn't terminate`;
   }
@@ -57,12 +57,12 @@ export async function performSequence<Ending, Reaction>(
 }
 
 /** Launches a new ActionSequence from the ActionPlan, then hands over to directSequence. */
-export async function directPlan<Ending, Reaction, Exit>(
+export async function performPlan<Ending, Reaction, Exit>(
   plan: ActionPlan<[], Ending, Reaction>,
   performer: Performer<never, Reaction>
 ): Promise<Ending | Termination> {
   let sequence = plan();
-  return directSequence(sequence, performer);
+  return performSequence(sequence, performer);
 }
 
 /** Hands Actions and Reactions between two co-routines.
@@ -70,7 +70,7 @@ export async function directPlan<Ending, Reaction, Exit>(
  * * A Performer (generates Reactions, consumes Actions)
  * */
 //TODO change argument order for consistency with 'performXXX' test library methods
-export async function directSequence<Ending, Reaction, Exit>(
+export async function performSequence<Ending, Reaction, Exit>(
   sequence: ActionSequence<Ending, Reaction>,
   performer: Performer<Exit, Reaction>
 ): Promise<Ending | Termination> {

--- a/packages/lauf-runner/test/core/schedule.test.ts
+++ b/packages/lauf-runner/test/core/schedule.test.ts
@@ -15,7 +15,7 @@ import {
   isExpiry,
 } from "@lauf/lauf-runner/core/delay";
 import { ActionPlan } from "@lauf/lauf-runner/types";
-import { performPlan } from "@lauf/lauf-runner/core/util";
+import { launchPlan } from "@lauf/lauf-runner/core/util";
 
 describe("Foreground and Background operations", () => {
   const delayMs = 10;
@@ -30,7 +30,7 @@ describe("Foreground and Background operations", () => {
   ];
 
   test("foreground : executes inner plan to completion", async () => {
-    const result = await performPlan(function* () {
+    const result = await launchPlan(function* () {
       return yield* foregroundPlan(simplePlan);
     });
     expect(isExpiry(result)).toBeTruthy();
@@ -38,7 +38,7 @@ describe("Foreground and Background operations", () => {
 
   test("foregroundAll : executes inner plans in parallel to completion", async () => {
     const before = new Date().getTime();
-    const endings = await performPlan<Expiry[], any>(function* () {
+    const endings = await launchPlan<Expiry[], any>(function* () {
       return yield* foregroundAllPlans(planGroup);
     });
     const after = new Date().getTime();
@@ -53,7 +53,7 @@ describe("Foreground and Background operations", () => {
 
   test("backgroundAll : yields array of completion promises", async () => {
     const before = new Date().getTime();
-    const endingPromises = await performPlan(function* () {
+    const endingPromises = await launchPlan(function* () {
       return yield* backgroundAllPlans(planGroup);
     });
     const after = new Date().getTime();
@@ -75,7 +75,7 @@ describe("Scheduling Action Sequences", () => {
     const specialPromise = new Promise((resolve) =>
       setTimeout(() => resolve(special), 10)
     );
-    const result = await performPlan(function* () {
+    const result = await launchPlan(function* () {
       return yield* wait(specialPromise);
     });
     expect(result).toStrictEqual(special);
@@ -86,7 +86,7 @@ describe("Scheduling Action Sequences", () => {
     const silver = wait(promiseDelay(4).then(() => "silver"));
     const bronze = wait(promiseDelay(6).then(() => "bronze"));
     const sequences = lodashShuffle([gold, silver, bronze]);
-    const [ending, sequence] = await performPlan(function* () {
+    const [ending, sequence] = await launchPlan(function* () {
       return yield* race(sequences);
     });
     expect(ending).toStrictEqual("gold");
@@ -97,7 +97,7 @@ describe("Scheduling Action Sequences", () => {
     const delayMs = 2;
     const timeoutMs = 10;
     const quickSequence = wait(promiseDelay(delayMs).then(() => "success"));
-    const quickResult = await performPlan(function* () {
+    const quickResult = await launchPlan(function* () {
       return yield* timeout(quickSequence, timeoutMs);
     });
     expect(quickResult).toStrictEqual("success");
@@ -108,7 +108,7 @@ describe("Scheduling Action Sequences", () => {
     const delayMs = 10;
     const timeoutMs = 2;
     const slowSequence = wait(promiseDelay(delayMs).then(() => "success"));
-    const slowResult = await performPlan(function* () {
+    const slowResult = await launchPlan(function* () {
       return yield* timeout(slowSequence, timeoutMs);
     });
     expect(slowResult).not.toEqual("success");
@@ -122,7 +122,7 @@ describe("Scheduling Action Sequences", () => {
       wait(promiseDelay(9).then(() => "bronze")),
     ];
     const before = new Date().getTime();
-    const result = await performPlan(function* () {
+    const result = await launchPlan(function* () {
       return yield* team(sequences);
     });
     const after = new Date().getTime();

--- a/packages/lauf-runner/test/core/util.test.ts
+++ b/packages/lauf-runner/test/core/util.test.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import { ActionPlan } from "@lauf/lauf-runner/types";
-import { performPlan } from "@lauf/lauf-runner/core/util";
+import { launchPlan } from "@lauf/lauf-runner/core/util";
 import { Delay, delay } from "@lauf/lauf-runner/core/delay";
 
 describe("Define, run and regression test simple plan", () => {
@@ -14,7 +14,7 @@ describe("Define, run and regression test simple plan", () => {
   };
 
   test("Run plan", async () => {
-    const totalMs = await performPlan(plan);
+    const totalMs = await launchPlan(plan);
     expect(totalMs).toBeGreaterThan(3);
   });
 

--- a/packages/lauf-store-runner/test/path.test.ts
+++ b/packages/lauf-store-runner/test/path.test.ts
@@ -1,4 +1,4 @@
-import { performPlan } from "@lauf/lauf-runner";
+import { launchPlan } from "@lauf/lauf-runner";
 import { Store, BasicStore } from "@lauf/lauf-store";
 import {
   getStorePath,
@@ -13,7 +13,7 @@ describe("Store operations using paths", () => {
     const plan = function* () {
       return yield* getStorePath(store, "poem[0]");
     };
-    const ending = await performPlan(plan);
+    const ending = await launchPlan(plan);
     expect(ending).toStrictEqual("Roses are red");
   });
 
@@ -23,7 +23,7 @@ describe("Store operations using paths", () => {
     const plan = function* () {
       return yield* setStorePath(store, "poem.roses", "white");
     };
-    const ending = await performPlan(plan);
+    const ending = await launchPlan(plan);
     expect(ending).toStrictEqual(store.getValue());
     expect(store.getValue()).toEqual({ poem: { roses: "white" } });
   });
@@ -34,7 +34,7 @@ describe("Store operations using paths", () => {
     const plan = function* () {
       return yield* setStorePath(store, "poem[0]", "Roses are white");
     };
-    const ending = await performPlan(plan);
+    const ending = await launchPlan(plan);
     expect(ending).toStrictEqual(store.getValue());
     expect(store.getValue()).toEqual({ poem: ["Roses are white"] });
   });
@@ -50,7 +50,7 @@ describe("Store operations using paths", () => {
         "poem.violets": "green",
       });
     };
-    const ending = await performPlan(plan);
+    const ending = await launchPlan(plan);
     expect(ending).toStrictEqual(store.getValue());
     expect(store.getValue()).toEqual({
       poem: { roses: "white", violets: "green" },

--- a/packages/lauf-store-runner/test/queue.test.ts
+++ b/packages/lauf-store-runner/test/queue.test.ts
@@ -1,14 +1,14 @@
 import { BasicMessageQueue } from "@lauf/lauf-queue";
 import { send, receive } from "@lauf/lauf-store-runner/queue";
-import { performPlan, performSequence } from "@lauf/lauf-runner";
+import { launchPlan, launchSequence } from "@lauf/lauf-runner";
 
 describe("send,receive behaviour", () => {
   test("Simple send and receive", async () => {
     const queue = new BasicMessageQueue();
-    const sendEnding = await performPlan(function* () {
+    const sendEnding = await launchPlan(function* () {
       return yield* send(queue, "foo");
     });
-    const receiveEnding = await performPlan(function* () {
+    const receiveEnding = await launchPlan(function* () {
       return yield* receive(queue);
     });
     expect(sendEnding).toEqual(true);
@@ -26,7 +26,7 @@ describe("send,receive behaviour", () => {
       const third = yield* receive(queue);
       return [first, second, third];
     };
-    const ending = await performPlan(plan);
+    const ending = await launchPlan(plan);
     expect(ending).toEqual(["foo", "bar", "baz"]);
   });
 
@@ -36,7 +36,7 @@ describe("send,receive behaviour", () => {
       const received = yield* receive(queue);
       return received;
     };
-    const endingPromise = performPlan(plan); //don't await
+    const endingPromise = launchPlan(plan); //don't await
     queue.send("foo");
     const ending = await endingPromise; //now await
     expect(ending).toEqual("foo");
@@ -46,9 +46,9 @@ describe("send,receive behaviour", () => {
     const maxItems = 2;
     const maxConsumers = Number.MAX_SAFE_INTEGER;
     const queue = new BasicMessageQueue<string>(maxItems, maxConsumers);
-    expect(await performSequence(send(queue, "foo"))).toEqual(true);
-    expect(await performSequence(send(queue, "bar"))).toEqual(true);
-    expect(await performSequence(send(queue, "baz"))).toEqual(false);
+    expect(await launchSequence(send(queue, "foo"))).toEqual(true);
+    expect(await launchSequence(send(queue, "bar"))).toEqual(true);
+    expect(await launchSequence(send(queue, "baz"))).toEqual(false);
   });
 
   test("receive: throws on oversubscribing queue", () => {


### PR DESCRIPTION
Rotate some names, so performXXX can be used exclusively where you pass a performer as the last arg.