### PR TITLE
Move some next ts webpack deps into top level

### DIFF
--- a/apps/lauf-example-mixer/package.json
+++ b/apps/lauf-example-mixer/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lauf-example-snake",
+  "name": "lauf-example-mixer",
   "version": "0.1.0",
   "private": true,
   "scripts": {
@@ -11,16 +11,11 @@
     "next": "^10.0.0",
     "react": "17.0.1",
     "react-dom": "17.0.1",
+    "react-is": "^17.0.1",
     "styled-components": "^5.2.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.13.8",
-    "@babel/preset-typescript": "^7.13.0",
-    "@types/react": "^17.0.2",
     "@types/styled-components": "^5.1.7",
-    "add": "^2.0.6",
-    "ts-loader": "^8.0.17",
-    "typescript": "^4.2.2",
-    "webpack": "^5.24.2"
+    "add": "^2.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "typecheck:changed": "lerna exec --since origin/master --include-dependents -- tsc --noEmit"
   },
   "devDependencies": {
+    "@babel/core": "^7.13.8",
+    "@babel/preset-typescript": "^7.13.0",
     "@testing-library/react": "^11.2.5",
     "@testing-library/react-hooks": "^5.1.0",
     "@types/jest": "^26.0.20",
@@ -43,7 +45,9 @@
     "prettier": "^2.2.1",
     "ts-jest": "^26.5.2",
     "ts-node": "^9.1.1",
-    "typescript": "^4.2.2"
+    "ts-loader": "^8.0.17",
+    "typescript": "^4.2.2",
+    "webpack": "^5.24.2"
   },
   "dependencies": {
     "react": "^17.0.1",


### PR DESCRIPTION
If there are a lot of next apps it will do no harm having the dev deps in common in the workspace root.