### PR TITLE
Add support for Tuples to Immutable type

### DIFF
--- a/modules/lauf-store/src/types/immutable.ts
+++ b/modules/lauf-store/src/types/immutable.ts
@@ -1,13 +1,19 @@
 import type { Draft } from "immer";
 
-export interface ImmutableArray<T> extends ReadonlyArray<Immutable<T>> {}
+// export interface ImmutableArray<T> extends ReadonlyArray<Immutable<T>> {}
+
+type ImmutableTuple<T extends any[]> = Readonly<
+  {
+    [Index in keyof T]: Immutable<T[Index]>;
+  }
+>;
 
 export type ImmutableObject<T> = {
   readonly [P in keyof T]: Immutable<T[P]>;
 };
 
-export type Immutable<T> = T extends (infer R)[]
-  ? ImmutableArray<R>
+export type Immutable<T> = T extends any[]
+  ? ImmutableTuple<T>
   : T extends object
   ? ImmutableObject<T>
   : T extends string | number | boolean | null


### PR DESCRIPTION
Previously Tuples were implicitly treated as arrays with `infer` judging the common superclass of its members. This tweak means that tuples get treated properly, with a fixed length and possibly differing types in each position.