### PR TITLE
Use ts-essentials DeepReadonly for Immutable

### DIFF
--- a/modules/lauf-store/package.json
+++ b/modules/lauf-store/package.json
@@ -11,5 +11,8 @@
     "immer": "^8.0.1",
     "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2"
+  },
+  "devDependencies": {
+    "ts-essentials": "^7.0.1"
   }
 }

--- a/modules/lauf-store/src/types/immutable.ts
+++ b/modules/lauf-store/src/types/immutable.ts
@@ -1,17 +1,8 @@
 import type { Draft } from "immer";
+import type { DeepReadonly } from "ts-essentials";
 
-export type ImmutableObject<T> = Readonly<
-  {
-    [K in keyof T]: Immutable<T[K]>;
-  }
->;
+type Immutable<T> = DeepReadonly<T>;
 
-export type Immutable<T> = T extends any[] | object
-  ? ImmutableObject<T>
-  : T extends string | number | boolean | null
-  ? Readonly<T>
-  : never;
+type Editor<T> = (draft: Draft<Immutable<T>>) => void;
 
-export type Editor<T> = (draft: Draft<Immutable<T>>) => void;
-
-export type { Draft };
+export type { Immutable, Draft, Editor };

--- a/yarn.lock
+++ b/yarn.lock
@@ -11395,6 +11395,11 @@ trim-off-newlines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
   integrity sha1-n5up2e+odkw4dpi8v+sshI8RrbM=
 
+ts-essentials@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-7.0.1.tgz#d205508cae0cdadfb73c89503140cf2228389e2d"
+  integrity sha512-8lwh3QJtIc1UWhkQtr9XuksXu3O0YQdEE5g79guDfhCaU1FWTDIEDZ1ZSx4HTHUmlJZ8L812j3BZQ4a0aOUkSA==
+
 ts-jest@^26.5.2:
   version "26.5.2"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.5.2.tgz#5281d6b44c2f94f71205728a389edc3d7995b0c4"


### PR DESCRIPTION
This PR retires the home-rolled Immutable type in favour of the community-maintained DeepReadonly.