### PR TITLE
Adopt symbols instead of const arrays

### DIFF
--- a/modules/lauf-runner/src/core/delay.ts
+++ b/modules/lauf-runner/src/core/delay.ts
@@ -1,7 +1,7 @@
 import { Action } from "../types";
 import { planOfAction } from "../core/util";
 
-export const EXPIRY = ["expiry"] as const;
+export const EXPIRY = Symbol("expiry");
 export type Expiry = typeof EXPIRY;
 export function isExpiry(value: any): value is Expiry {
   return value === EXPIRY;

--- a/modules/lauf-runner/src/types.ts
+++ b/modules/lauf-runner/src/types.ts
@@ -1,4 +1,4 @@
-export const TERMINATE = ["terminate"] as const;
+export const TERMINATE = Symbol("terminate");
 export type Termination = typeof TERMINATE;
 export function isTermination(value: any): value is Termination {
   return value === TERMINATE;


### PR DESCRIPTION
Retires the use of const arrays as status flags. Symbols are preferred and produce more digestible compiler errors in Typescript.