### PR TITLE
Configure first @lauf packages for publishing, issue beta and test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
-#Cefn
+#CEFN : Tooling compatibility
 .vscode
+# CEFN : Don't version build products
+apps/*/dist
+modules/*/dist
 # Logs
 logs
 *.log

--- a/modules/lauf-store-react/package.json
+++ b/modules/lauf-store-react/package.json
@@ -1,11 +1,17 @@
 {
   "name": "@lauf/lauf-store-react",
-  "version": "0.1.0",
-  "main": "index.js",
+  "version": "0.1.0-beta.1",
+  "main": "dist/index.js",
+  "files": [
+    "README.md",
+    "dist"
+  ],
   "license": "MIT",
   "scripts": {
     "test": "jest",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "build": "tsc --build ./tsconfig.build.json",
+    "beta": "yarn run test && yarn run build && yarn publish --tag=beta --access=public"
   },
   "peerDependencies": {
     "react": "^17.0.1"

--- a/modules/lauf-store-react/tsconfig.build.json
+++ b/modules/lauf-store-react/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "outDir": "./dist"
+  }
+}

--- a/modules/lauf-store/package.json
+++ b/modules/lauf-store/package.json
@@ -1,11 +1,17 @@
 {
   "name": "@lauf/lauf-store",
-  "version": "0.1.0",
-  "main": "index.js",
+  "version": "0.1.0-beta.2",
+  "files": [
+    "README.md",
+    "dist"
+  ],
+  "main": "dist/index.js",
   "license": "MIT",
   "scripts": {
     "test": "jest",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "build": "tsc",
+    "beta": "yarn run test && yarn run build && yarn publish --tag=beta --access=public"
   },
   "dependencies": {
     "immer": "^8.0.1",

--- a/modules/lauf-store/tsconfig.build.json
+++ b/modules/lauf-store/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "outDir": "./dist"
+  }
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,9 +1,71 @@
 {
   "exclude": ["node_modules", "dist"],
   "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@lauf/*": ["modules/*/src"]
-    }
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Basic Options */
+    // "incremental": true,                         /* Enable incremental compilation */
+    "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+    // "lib": [],                                   /* Specify library files to be included in the compilation. */
+    "allowJs": false /* Allow javascript files to be compiled. */,
+    // "checkJs": true,                             /* Report errors in .js files. */
+    "jsx": "react" /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */,
+    "declaration": true /* Generates corresponding '.d.ts' file. */,
+    // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "sourceMap": true /* Generates corresponding '.map' file. */,
+    // "outFile": "./",                             /* Concatenate and emit output to single file. */
+    // "outDir": "./",                              /* Redirect output structure to the directory. */
+    // "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                           /* Enable project compilation */
+    // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
+    // "removeComments": true,                      /* Do not emit comments to output. */
+    // "importHelpers": true,                       /* Import emit helpers from 'tslib'. */
+    "downlevelIteration": true /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */,
+    // "isolatedModules": true,                     /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true /* Enable all strict type-checking options. */,
+    // "noImplicitAny": true,                       /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                    /* Enable strict null checks. */
+    // "strictFunctionTypes": true,                 /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,                 /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,        /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                      /* Raise error on 'this' expressions with an implied 'any' type. */
+    "alwaysStrict": true /* Parse in strict mode and emit "use strict" for each source file. */,
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                      /* Report errors on unused locals. */
+    // "noUnusedParameters": true,                  /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,                   /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,          /* Report errors for fallthrough cases in switch statement. */
+    "noUncheckedIndexedAccess": true /* Include 'undefined' in index signature results */,
+    // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                             /* List of folders to include type definitions from. */
+    // "types": [],                                 /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+    // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,                /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                            /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                               /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,                     /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                       /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,              /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,               /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "skipLibCheck": true /* Skip type checking of declaration files. */,
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,72 +1,11 @@
 {
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig.json to read more about this file */
-
-    /* Basic Options */
-    // "incremental": true,                         /* Enable incremental compilation */
-    "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
-    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
-    // "lib": [],                                   /* Specify library files to be included in the compilation. */
-    "allowJs": false /* Allow javascript files to be compiled. */,
-    // "checkJs": true,                             /* Report errors in .js files. */
-    "jsx": "react" /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */,
-    // "declaration": true,                         /* Generates corresponding '.d.ts' file. */
-    // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    "sourceMap": true /* Generates corresponding '.map' file. */,
-    // "outFile": "./",                             /* Concatenate and emit output to single file. */
-    // "outDir": "./",                              /* Redirect output structure to the directory. */
-    // "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                           /* Enable project compilation */
-    // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
-    // "removeComments": true,                      /* Do not emit comments to output. */
-    "noEmit": true /* Do not emit outputs. */,
-    // "importHelpers": true,                       /* Import emit helpers from 'tslib'. */
-    "downlevelIteration": true /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */,
-    // "isolatedModules": true,                     /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-
-    /* Strict Type-Checking Options */
-    "strict": true /* Enable all strict type-checking options. */,
-    // "noImplicitAny": true,                       /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,                    /* Enable strict null checks. */
-    // "strictFunctionTypes": true,                 /* Enable strict checking of function types. */
-    // "strictBindCallApply": true,                 /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
-    // "strictPropertyInitialization": true,        /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                      /* Raise error on 'this' expressions with an implied 'any' type. */
-    "alwaysStrict": true /* Parse in strict mode and emit "use strict" for each source file. */,
-
-    /* Additional Checks */
-    // "noUnusedLocals": true,                      /* Report errors on unused locals. */
-    // "noUnusedParameters": true,                  /* Report errors on unused parameters. */
-    // "noImplicitReturns": true,                   /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true,          /* Report errors for fallthrough cases in switch statement. */
-    "noUncheckedIndexedAccess": true /* Include 'undefined' in index signature results */,
-    // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
-
-    /* Module Resolution Options */
-    // "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                             /* List of folders to include type definitions from. */
-    // "types": [],                                 /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
-    // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */
-    // "allowUmdGlobalAccess": true,                /* Allow accessing UMD globals from modules. */
-
-    /* Source Map Options */
-    // "sourceRoot": "",                            /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "",                               /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,                     /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                       /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
-    /* Experimental Options */
-    // "experimentalDecorators": true,              /* Enables experimental support for ES7 decorators. */
-    // "emitDecoratorMetadata": true,               /* Enables experimental support for emitting type metadata for decorators. */
-
-    /* Advanced Options */
-    "skipLibCheck": true /* Skip type checking of declaration files. */,
-    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
+    /** CEFN: Monorepo config **/
+    "baseUrl": ".",
+    "paths": {
+      "@lauf/*": ["modules/*/src"]
+    },
+    "noEmit": true /* Do not emit outputs. */
   }
 }


### PR DESCRIPTION
This PR aligns at least two of the modules with proper tsconfig.build.json and package.json files such that a `yarn run beta` will trigger a publish of the packages to npm.

Initially I have published only `@lauf/lauf-store` and `@lauf/lauf-store/react` as they have a simple API and can already be adopted usefully in cases where developers wish to isolate state management from React. The implementation of Queue and Lock are of a similar complexity and immediate validity. However @lauf/lauf-runner is still in flux with changes to reduce the dependence on generators to the bare minimum.

The packages are now live with the beta tag at https://www.npmjs.com/package/@lauf/lauf-store and https://www.npmjs.com/package/@lauf/lauf-store-react and I have tested that they are functional on a simple create-react-app project, which uses the package like...

```typescript
import { Store } from "@lauf/lauf-store";
import { useSelected } from "@lauf/lauf-store-react";
import { State } from "../App";

export function FlowerPoem(props: { store: Store<State> }) {
  const { store } = props;
  const roses = useSelected(store, (state) => state.roses);
  const violets = useSelected(store, (state) => state.violets);
  return (
    <>
      <p>Roses are {roses}</p>
      <p>Violets are {violets}</p>
    </>
  );
}
```

The PR can be followed up by a later change to https://github.com/cefn/lauf/blob/main/validate-packages.ts to force all modules to align with the preferred config.