### PR TITLE
Define dependencies, create published versions

### DIFF
--- a/apps/nextjs-mixer/package.json
+++ b/apps/nextjs-mixer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs-mixer",
-  "version": "0.1.0",
+  "version": "0.1.0-beta.6",
   "private": true,
   "scripts": {
     "dev": "NODE_OPTIONS='--inspect' next dev",
@@ -19,5 +19,12 @@
   "devDependencies": {
     "@types/styled-components": "^5.1.7",
     "typescript": "^4.2.2"
-  }
+  },
+  "homepage": "https://github.com/cefn/lauf#readme",
+  "bugs": {
+    "url": "https://github.com/cefn/lauf/issues",
+    "email": "lauf@cefn.com"
+  },
+  "author": "Cefn Hoile <github.com@cefn.com> (https://cefn.com)",
+  "repository": "github:cefn/lauf"
 }

--- a/apps/nextjs-mixer/src/plan.ts
+++ b/apps/nextjs-mixer/src/plan.ts
@@ -1,7 +1,7 @@
-import { BasicMessageQueue } from "@lauf/lauf-queue/src";
+import { BasicMessageQueue } from "@lauf/lauf-queue";
 import { edit, Receive, receive } from "@lauf/lauf-runner-primitives";
-import { ActionSequence, backgroundPlan } from "@lauf/lauf-runner/src";
-import { BasicStore, Immutable } from "@lauf/lauf-store/src";
+import { ActionSequence, backgroundPlan } from "@lauf/lauf-runner";
+import { BasicStore, Immutable } from "@lauf/lauf-store";
 
 import {
   AppModel,

--- a/apps/nextjs-mixer/src/view.tsx
+++ b/apps/nextjs-mixer/src/view.tsx
@@ -3,7 +3,7 @@ import Head from "next/head";
 import { useSelected } from "@lauf/lauf-store-react";
 
 import { AppModel, selectColor } from "./domain";
-import { performSequence } from "@lauf/lauf-runner/src";
+import { performSequence } from "@lauf/lauf-runner";
 import { mainPlan } from "./plan";
 
 export function ColorApp() {

--- a/apps/nextjs-mornington/package.json
+++ b/apps/nextjs-mornington/package.json
@@ -1,12 +1,12 @@
 {
   "name": "nextjs-mornington",
-  "version": "0.1.0",
+  "version": "0.1.0-beta.6",
   "private": true,
   "scripts": {
     "dev": "NODE_OPTIONS='--inspect' next dev",
     "build": "next build",
     "start": "next start",
-    "test": "jest --passWithNoTests",
+    "test": "jest",
     "check": "tsc --noEmit"
   },
   "dependencies": {
@@ -21,5 +21,12 @@
   "devDependencies": {
     "@types/styled-components": "^5.1.7",
     "typescript": "^4.2.2"
-  }
+  },
+  "homepage": "https://github.com/cefn/lauf#readme",
+  "bugs": {
+    "url": "https://github.com/cefn/lauf/issues",
+    "email": "lauf@cefn.com"
+  },
+  "author": "Cefn Hoile <github.com@cefn.com> (https://cefn.com)",
+  "repository": "github:cefn/lauf"
 }

--- a/apps/nextjs-snake/package.json
+++ b/apps/nextjs-snake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-snake",
-  "version": "0.1.0",
+  "version": "0.1.0-beta.6",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -29,5 +29,12 @@
     "ts-loader": "^8.0.17",
     "typescript": "^4.2.2",
     "webpack": "^5.24.2"
-  }
+  },
+  "homepage": "https://github.com/cefn/lauf#readme",
+  "bugs": {
+    "url": "https://github.com/cefn/lauf/issues",
+    "email": "lauf@cefn.com"
+  },
+  "author": "Cefn Hoile <github.com@cefn.com> (https://cefn.com)",
+  "repository": "github:cefn/lauf"
 }

--- a/apps/noredux-async/package.json
+++ b/apps/noredux-async/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noredux-async",
-  "version": "0.1.0",
+  "version": "0.1.0-beta.6",
   "main": "index.js",
   "license": "MIT",
   "scripts": {
@@ -19,10 +19,10 @@
     "style-loader": "^2.0.0",
     "ts-loader": "^8.0.17",
     "tsconfig-paths-webpack-plugin": "^3.3.0",
+    "typescript": "^4.2.2",
     "webpack": "^5.24.3",
     "webpack-cli": "^4.5.0",
-    "webpack-dev-server": "^3.11.2",
-    "typescript": "^4.2.2"
+    "webpack-dev-server": "^3.11.2"
   },
   "browserslist": {
     "production": [
@@ -36,5 +36,12 @@
       "last 1 safari version"
     ]
   },
-  "dependencies": {}
+  "private": true,
+  "homepage": "https://github.com/cefn/lauf#readme",
+  "bugs": {
+    "url": "https://github.com/cefn/lauf/issues",
+    "email": "lauf@cefn.com"
+  },
+  "author": "Cefn Hoile <github.com@cefn.com> (https://cefn.com)",
+  "repository": "github:cefn/lauf"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,9 @@
 {
-  "packages": ["modules/**", "apps/**"],
-  "version": "0.1.0",
+  "packages": [
+    "modules/**",
+    "apps/**"
+  ],
+  "version": "0.1.0-beta.6",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/modules/draft/lauf-node-runner/package.json
+++ b/modules/draft/lauf-node-runner/package.json
@@ -1,13 +1,27 @@
 {
   "name": "@lauf/lauf-node-runner",
   "version": "0.1.0",
-  "main": "index.js",
+  "private": true,
+  "main": "dist/index.js",
   "license": "MIT",
   "scripts": {
     "test": "jest",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "build": "tsc --build ./tsconfig.build.json",
+    "prepare": "yarn run test && yarn run build"
   },
   "devDependencies": {
     "typescript": "^4.2.2"
-  }
+  },
+  "files": [
+    "README.md",
+    "dist"
+  ],
+  "homepage": "https://github.com/cefn/lauf#readme",
+  "bugs": {
+    "url": "https://github.com/cefn/lauf/issues",
+    "email": "lauf@cefn.com"
+  },
+  "author": "Cefn Hoile <github.com@cefn.com> (https://cefn.com)",
+  "repository": "github:cefn/lauf"
 }

--- a/modules/draft/lauf-runner-stopwatch/package.json
+++ b/modules/draft/lauf-runner-stopwatch/package.json
@@ -1,13 +1,27 @@
 {
   "name": "@lauf/lauf-runner-stopwatch",
   "version": "0.1.0",
-  "main": "index.js",
+  "private": true,
+  "main": "dist/index.js",
   "license": "MIT",
   "scripts": {
-    "test": "jest --passWithNoTests",
-    "check": "tsc --noEmit"
+    "test": "jest",
+    "check": "tsc --noEmit",
+    "build": "tsc --build ./tsconfig.build.json",
+    "prepare": "yarn run test && yarn run build"
   },
   "devDependencies": {
     "typescript": "^4.2.2"
-  }
+  },
+  "files": [
+    "README.md",
+    "dist"
+  ],
+  "homepage": "https://github.com/cefn/lauf#readme",
+  "bugs": {
+    "url": "https://github.com/cefn/lauf/issues",
+    "email": "lauf@cefn.com"
+  },
+  "author": "Cefn Hoile <github.com@cefn.com> (https://cefn.com)",
+  "repository": "github:cefn/lauf"
 }

--- a/modules/lauf-lock/package.json
+++ b/modules/lauf-lock/package.json
@@ -1,13 +1,30 @@
 {
   "name": "@lauf/lauf-lock",
-  "version": "0.1.0",
-  "main": "index.js",
+  "version": "0.1.0-beta.6",
+  "main": "dist/index.js",
   "license": "MIT",
   "scripts": {
     "test": "jest",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "build": "tsc --build ./tsconfig.build.json",
+    "prepare": "yarn run test && yarn run build"
   },
   "devDependencies": {
     "typescript": "^4.2.2"
-  }
+  },
+  "files": [
+    "README.md",
+    "dist"
+  ],
+  "gitHead": "03bd2f443dd739f47240c303214f24d611aa4ddc",
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://github.com/cefn/lauf#readme",
+  "bugs": {
+    "url": "https://github.com/cefn/lauf/issues",
+    "email": "lauf@cefn.com"
+  },
+  "author": "Cefn Hoile <github.com@cefn.com> (https://cefn.com)",
+  "repository": "github:cefn/lauf"
 }

--- a/modules/lauf-lock/tsconfig.build.json
+++ b/modules/lauf-lock/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "outDir": "./dist"
+  }
+}

--- a/modules/lauf-queue/package.json
+++ b/modules/lauf-queue/package.json
@@ -1,13 +1,30 @@
 {
   "name": "@lauf/lauf-queue",
-  "version": "0.1.0",
-  "main": "index.js",
+  "version": "0.1.0-beta.6",
+  "main": "dist/index.js",
   "license": "MIT",
   "scripts": {
     "test": "jest",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "build": "tsc --build ./tsconfig.build.json",
+    "prepare": "yarn run test && yarn run build"
   },
   "devDependencies": {
     "typescript": "^4.2.2"
-  }
+  },
+  "files": [
+    "README.md",
+    "dist"
+  ],
+  "gitHead": "03bd2f443dd739f47240c303214f24d611aa4ddc",
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://github.com/cefn/lauf#readme",
+  "bugs": {
+    "url": "https://github.com/cefn/lauf/issues",
+    "email": "lauf@cefn.com"
+  },
+  "author": "Cefn Hoile <github.com@cefn.com> (https://cefn.com)",
+  "repository": "github:cefn/lauf"
 }

--- a/modules/lauf-queue/tsconfig.build.json
+++ b/modules/lauf-queue/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "outDir": "./dist"
+  }
+}

--- a/modules/lauf-runner-primitives/package.json
+++ b/modules/lauf-runner-primitives/package.json
@@ -1,13 +1,35 @@
 {
   "name": "@lauf/lauf-runner-primitives",
-  "version": "0.1.0",
-  "main": "index.js",
+  "version": "0.1.0-beta.6",
+  "main": "dist/index.js",
   "license": "MIT",
   "scripts": {
     "test": "jest",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "build": "tsc --build ./tsconfig.build.json",
+    "prepare": "yarn run test && yarn run build"
   },
   "devDependencies": {
     "typescript": "^4.2.2"
-  }
+  },
+  "files": [
+    "README.md",
+    "dist"
+  ],
+  "dependencies": {
+    "@lauf/lauf-queue": "^0.1.0-beta.6",
+    "@lauf/lauf-runner": "^0.1.0-beta.6",
+    "@lauf/lauf-store": "^0.1.0-beta.6"
+  },
+  "gitHead": "03bd2f443dd739f47240c303214f24d611aa4ddc",
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://github.com/cefn/lauf#readme",
+  "bugs": {
+    "url": "https://github.com/cefn/lauf/issues",
+    "email": "lauf@cefn.com"
+  },
+  "author": "Cefn Hoile <github.com@cefn.com> (https://cefn.com)",
+  "repository": "github:cefn/lauf"
 }

--- a/modules/lauf-runner-primitives/tsconfig.build.json
+++ b/modules/lauf-runner-primitives/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "outDir": "./dist"
+  }
+}

--- a/modules/lauf-runner-trial/package.json
+++ b/modules/lauf-runner-trial/package.json
@@ -1,13 +1,30 @@
 {
   "name": "@lauf/lauf-runner-trial",
-  "version": "0.1.0",
-  "main": "index.js",
+  "version": "0.1.0-beta.6",
+  "main": "dist/index.js",
   "license": "MIT",
   "scripts": {
-    "test": "jest --passWithNoTests",
-    "check": "tsc --noEmit"
+    "test": "jest",
+    "check": "tsc --noEmit",
+    "build": "tsc --build ./tsconfig.build.json",
+    "prepare": "yarn run test && yarn run build"
   },
   "devDependencies": {
     "typescript": "^4.2.2"
-  }
+  },
+  "files": [
+    "README.md",
+    "dist"
+  ],
+  "gitHead": "03bd2f443dd739f47240c303214f24d611aa4ddc",
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://github.com/cefn/lauf#readme",
+  "bugs": {
+    "url": "https://github.com/cefn/lauf/issues",
+    "email": "lauf@cefn.com"
+  },
+  "author": "Cefn Hoile <github.com@cefn.com> (https://cefn.com)",
+  "repository": "github:cefn/lauf"
 }

--- a/modules/lauf-runner-trial/tsconfig.build.json
+++ b/modules/lauf-runner-trial/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "outDir": "./dist"
+  }
+}

--- a/modules/lauf-runner/package.json
+++ b/modules/lauf-runner/package.json
@@ -1,13 +1,30 @@
 {
   "name": "@lauf/lauf-runner",
-  "version": "0.1.0",
-  "main": "index.js",
+  "version": "0.1.0-beta.6",
+  "main": "dist/index.js",
   "license": "MIT",
   "scripts": {
     "test": "jest",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "build": "tsc --build ./tsconfig.build.json",
+    "prepare": "yarn run test && yarn run build"
   },
   "devDependencies": {
     "typescript": "^4.2.2"
-  }
+  },
+  "files": [
+    "README.md",
+    "dist"
+  ],
+  "gitHead": "03bd2f443dd739f47240c303214f24d611aa4ddc",
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://github.com/cefn/lauf#readme",
+  "bugs": {
+    "url": "https://github.com/cefn/lauf/issues",
+    "email": "lauf@cefn.com"
+  },
+  "author": "Cefn Hoile <github.com@cefn.com> (https://cefn.com)",
+  "repository": "github:cefn/lauf"
 }

--- a/modules/lauf-runner/tsconfig.build.json
+++ b/modules/lauf-runner/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "outDir": "./dist"
+  }
+}

--- a/modules/lauf-store-react/README.md
+++ b/modules/lauf-store-react/README.md
@@ -1,0 +1,8 @@
+<img src="https://github.com/cefn/lauf/raw/main/vector/logo.png" alt="Logo - Image of Runner" align="left"><br></br>
+
+# Lauf Store React
+
+<sub><sup>Logo - Diego Naive, Noun Project.</sup></sub>
+<br></br>
+
+`@lauf/lauf-store-react` provides a binding for React apps to use the [@lauf/lauf-store](https://github.com/cefn/lauf/tree/main/modules/lauf-store) reactive state-management solution, a simple substitute for Flux/Redux based on [Immer](https://immerjs.github.io/immer/).

--- a/modules/lauf-store-react/package.json
+++ b/modules/lauf-store-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lauf/lauf-store-react",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.6",
   "main": "dist/index.js",
   "files": [
     "README.md",
@@ -11,7 +11,10 @@
     "test": "jest",
     "check": "tsc --noEmit",
     "build": "tsc --build ./tsconfig.build.json",
-    "beta": "yarn run test && yarn run build && yarn publish --tag=beta --access=public"
+    "prepare": "yarn run test && yarn run build"
+  },
+  "dependencies": {
+    "@lauf/lauf-store": "^0.1.0-beta.6"
   },
   "peerDependencies": {
     "react": "^17.0.1"
@@ -19,5 +22,16 @@
   "devDependencies": {
     "@testing-library/react": "^11.2.5",
     "typescript": "^4.2.2"
-  }
+  },
+  "gitHead": "03bd2f443dd739f47240c303214f24d611aa4ddc",
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://github.com/cefn/lauf#readme",
+  "bugs": {
+    "url": "https://github.com/cefn/lauf/issues",
+    "email": "lauf@cefn.com"
+  },
+  "author": "Cefn Hoile <github.com@cefn.com> (https://cefn.com)",
+  "repository": "github:cefn/lauf"
 }

--- a/modules/lauf-store/README.md
+++ b/modules/lauf-store/README.md
@@ -1,0 +1,12 @@
+<img src="https://github.com/cefn/lauf/raw/main/vector/logo.png" alt="Logo - Image of Runner" align="left"><br></br>
+
+# Lauf Store
+
+<sub><sup>Logo - Diego Naive, Noun Project.</sup></sub>
+<br></br>
+
+`@lauf/lauf-store` provides a minimal reactive state-management solution, a simple substitute for Flux/Redux based on [Immer](https://immerjs.github.io/immer/).
+
+It is incredibly lightweight and suitable for adoption with almost any server-side or client-side framework in Typescript or Javascript.
+
+A React binding is provided by the [@lauf/lauf-store-react](https://github.com/cefn/lauf/tree/main/modules/lauf-store-react) package

--- a/modules/lauf-store/package.json
+++ b/modules/lauf-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lauf/lauf-store",
-  "version": "0.1.0-beta.2",
+  "version": "0.1.0-beta.6",
   "files": [
     "README.md",
     "dist"
@@ -10,8 +10,8 @@
   "scripts": {
     "test": "jest",
     "check": "tsc --noEmit",
-    "build": "tsc",
-    "beta": "yarn run test && yarn run build && yarn publish --tag=beta --access=public"
+    "build": "tsc --build ./tsconfig.build.json",
+    "prepare": "yarn run test && yarn run build"
   },
   "dependencies": {
     "immer": "^8.0.1",
@@ -20,5 +20,16 @@
   },
   "devDependencies": {
     "typescript": "^4.2.2"
-  }
+  },
+  "gitHead": "03bd2f443dd739f47240c303214f24d611aa4ddc",
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://github.com/cefn/lauf#readme",
+  "bugs": {
+    "url": "https://github.com/cefn/lauf/issues",
+    "email": "lauf@cefn.com"
+  },
+  "author": "Cefn Hoile <github.com@cefn.com> (https://cefn.com)",
+  "repository": "github:cefn/lauf"
 }

--- a/validate-packages.ts
+++ b/validate-packages.ts
@@ -1,4 +1,12 @@
 #!/usr/bin/env -S npx ts-node
+/**
+ * An example of running this script surgically to fix just one property...
+ * npx ./validate-packages.ts
+ * ...will report on all errors and warnings...
+ * npx ./validate-packages.ts --filterPropertyPaths=publishConfig --strategy=dryRun
+ * ...to report errors for a specific property before force-fixing, then use the fixErrors strategy
+ * npx ./validate-packages.ts --filterPropertyPaths=publishConfig --strategy=fixErrors
+ */
 import assert from "assert";
 import fs from "fs";
 import glob from "glob";
@@ -11,6 +19,34 @@ import chalk from "chalk";
 
 const RULES: ReadonlyArray<PackageJsonRule> = [
   {
+    path: "homepage",
+    expected: "https://github.com/cefn/lauf#readme",
+    status: "error",
+  },
+  {
+    path: "author",
+    expected: "Cefn Hoile <github.com@cefn.com> (https://cefn.com)",
+    status: "error",
+  },
+  {
+    path: "repository",
+    expected: "github:cefn/lauf",
+    status: "error",
+  },
+  {
+    path: "bugs",
+    expected: {
+      url: "https://github.com/cefn/lauf/issues",
+      email: "lauf@cefn.com",
+    },
+    status: "error",
+  },
+  {
+    path: "devDependencies.typescript",
+    expected: "^4.2.2",
+    status: "error",
+  },
+  {
     path: "scripts.test",
     expected: "jest",
     status: "warning",
@@ -21,24 +57,81 @@ const RULES: ReadonlyArray<PackageJsonRule> = [
     status: "error",
   },
   {
-    path: "devDependencies.typescript",
-    expected: "^4.2.2",
+    path: "scripts.prepare",
+    expected: "yarn run test && yarn run build",
+    packagePaths: "modules/**",
+    status: "error",
+  },
+  {
+    path: "license",
+    expected: "MIT",
+    packagePaths: "modules/**",
+    status: "error",
+  },
+  {
+    path: "scripts.beta",
+    expected: undefined,
+    packagePaths: "modules/**",
+    status: "error",
+  },
+  {
+    path: "scripts.build",
+    expected: "tsc --build ./tsconfig.build.json",
+    packagePaths: "modules/**",
+    status: "error",
+  },
+  {
+    path: "main",
+    expected: "dist/index.js",
+    packagePaths: "modules/**",
+    status: "error",
+  },
+  {
+    path: "files",
+    expected: ["README.md", "dist"],
+    packagePaths: "modules/**",
+    status: "error",
+  },
+  {
+    path: "private",
+    expected: true,
+    packagePaths: "apps/**",
+    status: "error",
+  },
+  {
+    path: "private",
+    expected: true,
+    packagePaths: "modules/draft/*/package.json",
+    status: "error",
+  },
+  {
+    path: "private",
+    expected: undefined,
+    packagePaths: "modules/*/package.json",
+    status: "error",
+  },
+  {
+    path: "publishConfig",
+    expected: {
+      access: "public",
+    },
+    packagePaths: "modules/*/package.json",
     status: "error",
   },
 ] as const;
 
-const { strategy, filterPackages, filterPaths } = yargs
+const { strategy, filterPackagePaths, filterPropertyPaths } = yargs
   .option("strategy", {
     description: "Select alignment strategy",
     type: "string",
     default: "dryRun",
     choices: ["dryRun", "fixErrors", "fixWarnings"],
   })
-  .option("filterPackages", {
-    description: "Filter pattern for package names",
+  .option("filterPackagePaths", {
+    description: "Filter pattern for package paths",
     type: "string",
   })
-  .option("filterPaths", {
+  .option("filterPropertyPaths", {
     description: "Filter pattern for property names",
     type: "string",
   })
@@ -52,26 +145,32 @@ const STATUSES = [
 
 type Status = typeof STATUSES[number];
 type Rule = typeof RULES[number];
+type Expected = true | string | object | RegExp | undefined;
 
 interface PackageJsonRule {
   /** The path to get/set within package.json (lodash) */
   path: string;
   /** The value or pattern expected at that path */
-  expected: string | RegExp;
+  expected: Expected;
+  /** A minimatch filter limiting this rule to certain packages */
+  packagePaths?: string;
+  /** Whether this should count as a warning, error */
   status: Status;
 }
 
-const packageJsonPaths = glob.sync("**/package.json", {
-  ignore: "**/node_modules/**/package.json",
-});
+const packageJsonPaths = glob
+  .sync("**/package.json", {
+    ignore: "**/node_modules/**/package.json",
+  })
+  .sort();
 
 let failed = false;
 
 for (const packageJsonPath of packageJsonPaths) {
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath).toString());
 
-  if (filterPackages) {
-    if (!minimatch(packageJson.name, filterPackages)) {
+  if (filterPackagePaths) {
+    if (!minimatch(packageJsonPath, filterPackagePaths)) {
       continue;
     }
   }
@@ -85,15 +184,21 @@ for (const packageJsonPath of packageJsonPaths) {
 
   //traverse package json tree, checking and (optionally) fixing
   type Violation = {
-    actual: string;
-    expected: string | RegExp;
+    actual: any;
+    expected: Expected;
     fixed: boolean;
   };
   const found: Record<Rule["path"], Violation> = {};
   let rewritePackageJson = false;
-  for (const { path, expected, status } of RULES) {
-    if (filterPaths) {
-      if (!minimatch(path, filterPaths)) {
+  for (const { path, expected, status, packagePaths } of RULES) {
+    if (filterPropertyPaths) {
+      if (!minimatch(path, filterPropertyPaths)) {
+        continue;
+      }
+    }
+
+    if (packagePaths) {
+      if (!minimatch(packageJsonPath, packagePaths)) {
         continue;
       }
     }
@@ -112,7 +217,9 @@ for (const packageJsonPath of packageJsonPaths) {
       }
       const message = `${violationColor(
         status.toUpperCase()
-      )} ${path} was '${chalk.red(actual)}' not '${chalk.green(expected)}'`;
+      )} ${path} was '${chalk.red(actual)}' not '${chalk.green(
+        JSON.stringify(expected)
+      )}'`;
       //check strategy, possibly skip fix depending on rule status
       if (
         (status === "error" && ["dryRun"].includes(strategy)) ||
@@ -137,12 +244,17 @@ for (const packageJsonPath of packageJsonPaths) {
       console.log(
         `${chalk.yellow(path)} ${chalk.red(actual)}${chalk.yellow(
           " not "
-        )}${chalk.green(expected)} (${
+        )}${chalk.green(JSON.stringify(expected))} (${
           fixed ? "FIXED" : `NOT FIXED (${strategy})`
         })`
       );
     }
   }
+
+  // const packageDir = dirname(packageJsonPath);
+  // const tsconfigBuildPath = `${packageDir}/tsconfig.build.json`;
+  // const tsconfigBuild = JSON.parse(fs.readFileSync(packageJsonPath).toString());
+  //Implement this using a `skel` folder instead
 
   if (rewritePackageJson) {
     fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, "  "));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1222,6 +1222,11 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@lauf/lauf-runner@^0.1.0-beta.3":
+  version "0.1.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@lauf/lauf-runner/-/lauf-runner-0.1.0-beta.3.tgz#e6c2a58abfc81e58e5c225511bc99fda8178ebf1"
+  integrity sha512-iFY4r/4hQud8IxT4pkB0JGDkuYlt417FuD4clwtMUrXRvtegB+KzNqUrGBFl0zBkaZeoKfqgTHDgJqGDOEmePw==
+
 "@lerna/add@4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-4.0.0.tgz#c36f57d132502a57b9e7058d1548b7a565ef183f"


### PR DESCRIPTION
This PR is intended to configure all modules to have the proper package metadata to publish, to be the basis for initially publishing a version of each package and then align packages which have monorepo dependents by adding explicit dependencies to them (this will fail until there is a version published in npm).

The packages have not yet all been published and the relative dependencies not yet recorded. 

The following script gives a good summary of relative monorepo dependencies when run within a particular package, to consider candidates to be added to dependencies, peerDependencies. 

```sh
`grep --recursive --no-filename --only-matching --extended-regexp '"@lauf/[a-z-]+"' . | sort -u`
```

It is expected to make all internal dependencies to be actual dependencies as the published versions can have their explicit versioned interdependency recorded that way.