### PR TITLE
Do not transform types of functions

### DIFF
--- a/modules/lauf-store/src/types/immutable.ts
+++ b/modules/lauf-store/src/types/immutable.ts
@@ -7,6 +7,7 @@ export type ImmutableObject<T> = Readonly<
 >;
 
 export type Immutable<T> = T extends
+  | ((...args: any[]) => any)
   | string
   | number
   | boolean


### PR DESCRIPTION
This change potentially addresses the issue experienced in downstream projects, where if functions were members of the state tree, their type was transformed to readonly Object as they weren't treated as primitives. That meant it was impossible to invoke them. This situation could be arrived at explicitly (e.g. where a list of accessor functions is used in the state to record a field sort order) or implicitly (where e.g. a builtin like Date has functions like getTime() that you wish to run).