### PR TITLE
Suppress declarations inherited from build config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "paths": {
       "@lauf/*": ["modules/*/src"]
     },
+    "declaration": false,
     "noEmit": true /* Do not emit outputs. */
   }
 }


### PR DESCRIPTION
Local development was being strewn with .d.ts files after enabling type declaration exporting for publishing. This config can be limited to just tsconfig.build.json