### PR TITLE
Add castDraft to exports

### DIFF
--- a/modules/lauf-store/src/core/index.ts
+++ b/modules/lauf-store/src/core/index.ts
@@ -1,3 +1,4 @@
 export * from "./path";
 export * from "./store";
 export * from "./watchable";
+export { castDraft } from "immer";


### PR DESCRIPTION
This works around some dead-ends where you have an Immutable data object, but it needs to be used within an Editor (which expects mutable drafts).