### PR TITLE
Schedule notifications in next tick to force notification order

### DIFF
--- a/modules/lauf-store/src/core/watchable.ts
+++ b/modules/lauf-store/src/core/watchable.ts
@@ -5,8 +5,10 @@ export class BasicWatchable<Value> implements Watchable<Value> {
   constructor(watchers: ReadonlyArray<Watcher<Value>> = []) {
     this.watchers = watchers;
   }
-  protected notify = (item: Value) => {
-    for (const watcher of this.watchers) {
+  protected notify = async (item: Value) => {
+    const watchers = this.watchers;
+    await Promise.resolve();
+    for (const watcher of watchers) {
       watcher(item);
     }
   };

--- a/modules/lauf-store/test/core/watchable.test.ts
+++ b/modules/lauf-store/test/core/watchable.test.ts
@@ -12,20 +12,22 @@ describe("BasicWatchable behaviour", () => {
     }
   }
 
-  test("Can watch BasicWatchable", () => {
+  test("Can watch BasicWatchable", async () => {
     const notifiable = new Notifiable<string>();
     const watcher = jest.fn();
     notifiable.watch(watcher);
     notifiable.doNotify("foo");
+    await Promise.resolve(); //wait one tick for notifications
     expect(watcher).toHaveBeenCalledWith("foo");
   });
 
-  test("Can unwatch BasicWatchable", () => {
+  test("Can unwatch BasicWatchable", async () => {
     const notifiable = new Notifiable<string>();
     const watcher = jest.fn();
     const unwatch = notifiable.watch(watcher);
     unwatch();
     notifiable.doNotify("foo");
+    await Promise.resolve(); //wait one tick for notifications
     expect(watcher).not.toHaveBeenCalled();
   });
 });
@@ -39,21 +41,24 @@ describe("BasicWatchableValue behaviour", () => {
     new BasicWatchableValue<Record<string, any>>({});
   });
 
-  test("Can watch BasicWatchableValue", () => {
+  test("Can watch BasicWatchableValue", async () => {
     const watchableValue = new BasicWatchableValue<string>("foo");
     const watcher = jest.fn();
     watchableValue.watch(watcher);
     watchableValue.write("bar");
+    await Promise.resolve(); //wait one tick for notifications
     expect(watcher).toHaveBeenCalledWith("bar");
   });
 
-  test("Can watch BasicWatchableValue from moment of construction", () => {
+  test("Can watch BasicWatchableValue from moment of construction", async () => {
     const watcher = jest.fn();
     const watchers = [watcher];
     const watchableValue = new BasicWatchableValue<string>("foo", watchers);
+    await Promise.resolve(); //wait one tick for notifications
     expect(watcher).toHaveBeenCalledWith("foo");
     watcher.mockClear();
     watchableValue.write("bar");
+    await Promise.resolve(); //wait one tick for notifications
     expect(watcher).toHaveBeenCalledWith("bar");
   });
 


### PR DESCRIPTION
This ensures that Watcher notifications from a state change happen in the next tick, to prevent sequences like the one depicted below where Edits are re-entrant (an edit triggered a notify which triggered an edit). Here the third listener gets notified of the change to B before notified of the change to A, meaning it has an inconsistent record of state.

* Edit
* Write A
  - Notify A
  - Notify A
    * Edit
    * Write B
      - Notify B
      - Notify B
      - Notify B
  - Notify A

Putting notifications in the next tick means this behaves as follows, ensuring that notifications are in order...

* Edit
* Write A
  - Schedule A
  - Notify A
  - Notify A
    * Edit
    * Write B
      - Schedule B
  - Notify A
  - Notify B
  - Notify B
  - Notify B
