### PR TITLE
Add, assert homepage validation rule to deep-link modules

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,4 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
-name: Node.js CI
+name: Node.js Test CI
 
 on:
   push:
@@ -15,8 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        node-version: [10.x, 12.x, 14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/modules/draft/lauf-node-runner/package.json
+++ b/modules/draft/lauf-node-runner/package.json
@@ -17,7 +17,7 @@
     "README.md",
     "dist"
   ],
-  "homepage": "https://github.com/cefn/lauf#readme",
+  "homepage": "https://github.com/cefn/lauf/tree/main/modules/lauf-node-runner#readme",
   "bugs": {
     "url": "https://github.com/cefn/lauf/issues",
     "email": "lauf@cefn.com"

--- a/modules/draft/lauf-runner-stopwatch/package.json
+++ b/modules/draft/lauf-runner-stopwatch/package.json
@@ -17,7 +17,7 @@
     "README.md",
     "dist"
   ],
-  "homepage": "https://github.com/cefn/lauf#readme",
+  "homepage": "https://github.com/cefn/lauf/tree/main/modules/lauf-runner-stopwatch#readme",
   "bugs": {
     "url": "https://github.com/cefn/lauf/issues",
     "email": "lauf@cefn.com"

--- a/modules/lauf-lock/package.json
+++ b/modules/lauf-lock/package.json
@@ -20,7 +20,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "homepage": "https://github.com/cefn/lauf#readme",
+  "homepage": "https://github.com/cefn/lauf/tree/main/modules/lauf-lock#readme",
   "bugs": {
     "url": "https://github.com/cefn/lauf/issues",
     "email": "lauf@cefn.com"

--- a/modules/lauf-queue/package.json
+++ b/modules/lauf-queue/package.json
@@ -20,7 +20,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "homepage": "https://github.com/cefn/lauf#readme",
+  "homepage": "https://github.com/cefn/lauf/tree/main/modules/lauf-queue#readme",
   "bugs": {
     "url": "https://github.com/cefn/lauf/issues",
     "email": "lauf@cefn.com"

--- a/modules/lauf-runner-primitives/package.json
+++ b/modules/lauf-runner-primitives/package.json
@@ -25,7 +25,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "homepage": "https://github.com/cefn/lauf#readme",
+  "homepage": "https://github.com/cefn/lauf/tree/main/modules/lauf-runner-primitives#readme",
   "bugs": {
     "url": "https://github.com/cefn/lauf/issues",
     "email": "lauf@cefn.com"

--- a/modules/lauf-runner-trial/package.json
+++ b/modules/lauf-runner-trial/package.json
@@ -20,7 +20,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "homepage": "https://github.com/cefn/lauf#readme",
+  "homepage": "https://github.com/cefn/lauf/tree/main/modules/lauf-runner-trial#readme",
   "bugs": {
     "url": "https://github.com/cefn/lauf/issues",
     "email": "lauf@cefn.com"

--- a/modules/lauf-runner/package.json
+++ b/modules/lauf-runner/package.json
@@ -20,7 +20,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "homepage": "https://github.com/cefn/lauf#readme",
+  "homepage": "https://github.com/cefn/lauf/tree/main/modules/lauf-runner#readme",
   "bugs": {
     "url": "https://github.com/cefn/lauf/issues",
     "email": "lauf@cefn.com"

--- a/modules/lauf-runner/test/core/schedule.test.ts
+++ b/modules/lauf-runner/test/core/schedule.test.ts
@@ -14,7 +14,7 @@ import {
 } from "@lauf/lauf-runner";
 
 describe("Foreground and Background operations", () => {
-  const delayMs = 10;
+  const delayMs = 15;
   const simplePlan: ActionPlan<[], Expiry, Expiry> = function* () {
     return yield* expire(delayMs);
   };

--- a/modules/lauf-runner/test/core/util.test.ts
+++ b/modules/lauf-runner/test/core/util.test.ts
@@ -13,7 +13,7 @@ import {
 describe("Define, run and regression test simple plan", () => {
   const plan: ActionPlan<[], number, Expiry> = function* () {
     const beforeMs = new Date().getTime();
-    for (let i = 0; i < 3; i++) {
+    for (let i = 0; i < 4; i++) {
       yield* expire(i);
     }
     const afterMs = new Date().getTime();
@@ -43,6 +43,11 @@ describe("Define, run and regression test simple plan", () => {
     assert(step.done === false);
     expect(step.value).toBeInstanceOf(Expire);
     expect((step.value as Expire).ms).toBe(2);
+
+    step = sequence.next();
+    assert(step.done === false);
+    expect(step.value).toBeInstanceOf(Expire);
+    expect((step.value as Expire).ms).toBe(3);
 
     step = sequence.next();
     assert(step.done === true);

--- a/modules/lauf-store-react/package.json
+++ b/modules/lauf-store-react/package.json
@@ -27,7 +27,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "homepage": "https://github.com/cefn/lauf#readme",
+  "homepage": "https://github.com/cefn/lauf/tree/main/modules/lauf-store-react#readme",
   "bugs": {
     "url": "https://github.com/cefn/lauf/issues",
     "email": "lauf@cefn.com"

--- a/modules/lauf-store/package.json
+++ b/modules/lauf-store/package.json
@@ -25,7 +25,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "homepage": "https://github.com/cefn/lauf#readme",
+  "homepage": "https://github.com/cefn/lauf/tree/main/modules/lauf-store#readme",
   "bugs": {
     "url": "https://github.com/cefn/lauf/issues",
     "email": "lauf@cefn.com"

--- a/modules/lauf-store/src/core/watchable.ts
+++ b/modules/lauf-store/src/core/watchable.ts
@@ -7,7 +7,7 @@ export class BasicWatchable<Value> implements Watchable<Value> {
   }
   protected notify = async (item: Value) => {
     const watchers = this.watchers;
-    await Promise.resolve();
+    await Promise.resolve(); //equivalent to queueMicrotask()
     for (const watcher of watchers) {
       watcher(item);
     }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "check": "lerna run check",
     "check:changed": "lerna run --since origin/main --include-dependents check",
     "check:lauf": "lerna run --scope '@lauf/*' check",
-    "validate": "npx ts-node ./validate-packages.ts"
+    "validate": "ts-node ./validate-packages.ts",
+    "release": "lerna publish"
   },
   "devDependencies": {
     "@babel/core": "^7.13.8",


### PR DESCRIPTION
This ensures that consumers of individual lauf modules don't end up lost looking at the top level monorepo readme. Instead they will land at the module-specific readme.