### PR TITLE
Middleware not performer

### DIFF
--- a/docs/discussion/examples/index/actions/good/test/dialog.test.ts
+++ b/docs/discussion/examples/index/actions/good/test/dialog.test.ts
@@ -1,9 +1,10 @@
-import { directSequence, isTermination } from "@lauf/lauf-runner";
 import {
-  performUntilActionFulfils,
-  createActionMatcher,
-  performWithMocks,
-} from "@lauf/lauf-runner-trial";
+  Action,
+  directSequence,
+  isTermination,
+  TERMINATE,
+} from "@lauf/lauf-runner";
+import { actionMatches } from "@lauf/lauf-runner-trial";
 
 import { Prompt } from "../prompt";
 
@@ -11,12 +12,14 @@ import { dialogPlan } from "../dialog";
 
 describe("Dialog ", () => {
   test("dialogPlan() prompts for name - minimal test", async () => {
-    await directSequence(
-      dialogPlan(),
-      performUntilActionFulfils(
-        createActionMatcher(new Prompt("What is your full name?: "))
-      )
-    );
+    await directSequence(dialogPlan(), async (action: Action<any>) => {
+      if (
+        actionMatches<string>(new Prompt("What is your full name?: "), action)
+      ) {
+        return TERMINATE;
+      }
+      return await action.act();
+    });
   });
 
   test("dialogPlan() prompts for name - detailed test", async () => {

--- a/modules/lauf-runner-trial/src/perform.ts
+++ b/modules/lauf-runner-trial/src/perform.ts
@@ -1,81 +1,16 @@
-import { isDeepStrictEqual } from "util";
-import { Action, Performance, actor, isAction } from "@lauf/lauf-runner";
+import { Action } from "@lauf/lauf-runner";
 
 type ActionCheck = (candidate: Action<any>) => boolean;
 
-function actionMatches<Actual extends Action<any>, Expected extends Actual>(
-  actual: Actual,
-  expected: Expected
-): actual is Expected {
+export function actionMatches<
+  ExpectedReaction extends ActualReaction,
+  ActualReaction = any
+>(
+  actual: Action<ActualReaction>,
+  expected: Action<ExpectedReaction>
+): actual is Action<ExpectedReaction> {
   return (
     actual.constructor === expected.constructor &&
     JSON.stringify(actual) === JSON.stringify(expected)
   );
-}
-
-export function createActionMatcher<Reaction>(expected: Action<Reaction>) {
-  return (candidate: Action<Reaction>) => {
-    return actionMatches(candidate, expected);
-  };
-}
-
-export async function* performUntilActionFulfils<Reaction>(
-  criterion: (candidate: Action<Reaction>) => boolean,
-  performance: Performance<any, Reaction> = actor()
-): Performance<Action<Reaction>, Reaction> {
-  let { value: reaction, done } = await performance.next();
-  let action = yield undefined as any;
-  do {
-    if (criterion(action)) {
-      return action;
-    }
-    ({ value: reaction, done } = await performance.next(action));
-    action = yield reaction;
-  } while (!done);
-  throw `Performer with Exit:never should consume actions forever`;
-}
-
-export async function* performUntilReactionFulfils<Reaction>(
-  criterion: (candidate: Reaction) => boolean,
-  performance: Performance<any, Reaction> = actor()
-): Performance<Reaction, Reaction> {
-  await performance.next();
-  let reaction, done;
-  let action = yield undefined as any;
-  do {
-    ({ value: reaction, done } = await performance.next(action));
-    if (criterion(reaction)) {
-      return reaction;
-    }
-    action = yield reaction;
-  } while (!done);
-  throw `Performer with Exit:never should consume actions forever`;
-}
-
-export async function* performWithMocks<Reaction>(
-  mocks: Array<[ActionCheck | Action<any>, Reaction]>,
-  performance: Performance<any, Reaction> = actor()
-): Performance<never, Reaction> {
-  //substitute action 'checks' with a matcher for the action
-  const normalisedMocks = mocks.map<[ActionCheck, Reaction]>(
-    ([check, mocked]) => [
-      isAction(check) ? createActionMatcher(check) : check,
-      mocked,
-    ]
-  );
-  await performance.next();
-  let reaction, done;
-  let action = yield undefined as any;
-  do {
-    for (const [check, mocked] of normalisedMocks) {
-      if (check(action)) {
-        //substitute mocked data
-        action = yield mocked;
-        continue;
-      }
-    }
-    ({ value: reaction, done } = await performance.next(action));
-    action = yield reaction;
-  } while (!done);
-  throw `Performer with Exit:never should consume actions forever`;
 }

--- a/modules/lauf-runner-trial/test/index.test.ts
+++ b/modules/lauf-runner-trial/test/index.test.ts
@@ -1,9 +1,4 @@
-import {
-  createActionMatcher,
-  performWithMocks,
-  performUntilActionFulfils,
-  performUntilReactionFulfils,
-} from "../src/perform";
+import { createActionMatcher, performWithMocks } from "../src/perform";
 
 describe("", () => {
   test("", () => {});

--- a/modules/lauf-runner/src/core/delay.ts
+++ b/modules/lauf-runner/src/core/delay.ts
@@ -1,5 +1,4 @@
-import { Action } from "../types";
-import { planOfAction } from "../core/util";
+import { planOfFunction } from "../core/util";
 
 export const EXPIRY = ["expiry"] as const;
 export type Expiry = typeof EXPIRY;
@@ -16,11 +15,4 @@ export function promiseExpiry(ms: number): Promise<Expiry> {
   return promiseDelayValue(ms, EXPIRY);
 }
 
-export class Expire implements Action<Expiry> {
-  constructor(readonly ms: number) {}
-  act() {
-    return promiseExpiry(this.ms);
-  }
-}
-
-export const expire = planOfAction(Expire);
+export const expire = planOfFunction(promiseExpiry);

--- a/modules/lauf-runner/src/core/util.ts
+++ b/modules/lauf-runner/src/core/util.ts
@@ -1,21 +1,14 @@
 import {
   ActionPlan,
   ActionClass,
-  Performer,
   ActionSequence,
-  TERMINATE,
-  Termination,
-  isTermination,
-  Performance,
+  Action,
+  ActionPerformer,
 } from "../types";
 
-export const actor: Performer<never, any> = async function* () {
-  let action = yield;
-  while (true) {
-    const reaction = await action.act();
-    action = yield reaction;
-  }
-};
+export const DEFAULT_PERFORMER: ActionPerformer = <Reaction>(
+  action: Action<Reaction>
+) => action.act();
 
 /** Streamline plan creation from any Action class. */
 export function planOfAction<Args extends any[], Ending>(
@@ -32,31 +25,23 @@ export async function performPlan<Args extends any[], Ending, Reaction>(
   plan: ActionPlan<Args, Ending, Reaction>,
   ...args: Args
 ): Promise<Ending> {
-  const ending = await directPlan(plan, args);
-  if (isTermination(ending)) {
-    throw `Performer with Exit:never shouldn't terminate`;
-  }
-  return ending;
+  return await directPlan(plan, args, DEFAULT_PERFORMER);
 }
 
 export async function performSequence<Ending, Reaction>(
   sequence: ActionSequence<Ending, Reaction>
 ): Promise<Ending> {
-  const ending = await directSequence(sequence);
-  if (isTermination(ending)) {
-    throw `Performer with Exit:never shouldn't terminate`;
-  }
-  return ending;
+  return await directSequence(sequence, DEFAULT_PERFORMER);
 }
 
 /** Launches a new ActionSequence from the ActionPlan, then hands over to directSequence. */
 export async function directPlan<Args extends any[], Ending, Reaction>(
   plan: ActionPlan<Args, Ending, Reaction>,
   args: Args,
-  performance: Performance<any, Reaction> = actor()
-): Promise<Ending | Termination> {
+  performer: ActionPerformer
+): Promise<Ending> {
   let sequence = plan(...args);
-  return directSequence(sequence, performance);
+  return directSequence(sequence, performer);
 }
 
 /** Hands Actions and Reactions between two co-routines.
@@ -66,24 +51,17 @@ export async function directPlan<Args extends any[], Ending, Reaction>(
 //TODO change argument order for consistency with 'performXXX' test library methods
 export async function directSequence<Ending, Reaction, Exit>(
   sequence: ActionSequence<Ending, Reaction>,
-  performance: Performance<any, Reaction> = actor()
-): Promise<Ending | Termination> {
+  performer: ActionPerformer
+): Promise<Ending> {
   let sequenceResult = sequence.next(); //prime the sequence
-  if (sequenceResult.done) {
-    return sequenceResult.value;
-  }
-  let performanceResult = await performance.next(); //prime the performer
-  if (performanceResult.done) {
-    return TERMINATE;
-  }
   while (true) {
-    performanceResult = await performance.next(sequenceResult.value);
-    if (performanceResult.done) {
-      return TERMINATE;
-    }
-    sequenceResult = sequence.next(performanceResult.value);
+    //sequence finished, return ending
     if (sequenceResult.done) {
       return sequenceResult.value;
     }
+    //sequence continued, perform action
+    const reaction = await performer(sequenceResult.value);
+    //pass result of action, get next action
+    sequenceResult = sequence.next(reaction);
   }
 }

--- a/modules/lauf-runner/src/types.ts
+++ b/modules/lauf-runner/src/types.ts
@@ -8,13 +8,14 @@ export interface Action<Reaction> {
   act: () => Reaction | Promise<Reaction>;
 }
 
+/** Duck-typing of Action */
+export function isAction(item: any): item is Action<any> {
+  return typeof item.act === "function" && item.act.length === 0;
+}
+
 /** Utility interface defining classes that implement Action */
 export interface ActionClass<Params extends any[], Reaction> {
   new (...params: Params): Action<Reaction>;
-}
-
-export function isAction(item: any): item is Action<any> {
-  return typeof item.act === "function" && item.act.length === 0;
 }
 
 /** An ActionSequence is a Generator with a next() that yields actions and
@@ -27,21 +28,11 @@ export type ActionSequence<Ending, Reaction> = Generator<
   Reaction
 >;
 
-// export type ActionSequenceIteration<Ending, Reaction> = [
-//   IteratorResult<Action<Reaction>, Ending>,
-//   ActionSequence<Ending, Reaction>
-// ];
-
 /** ActionPlan contains step-by-step instructions for an ActionSequence. */
 export type ActionPlan<Args extends any[], Ending, Reaction> = (
   ...args: Args
 ) => ActionSequence<Ending, Reaction>;
 
-//TODO add Sync routine as an option for testing?
-export type Performance<Exit, Reaction> = AsyncGenerator<
-  Reaction,
-  Exit,
-  Action<Reaction>
->;
-
-export type Performer<Exit, Reaction> = () => Performance<Exit, Reaction>;
+export type ActionPerformer = <Reaction>(
+  action: Action<Reaction>
+) => Reaction | Promise<Reaction>;

--- a/modules/lauf-runner/test/core/schedule.test.ts
+++ b/modules/lauf-runner/test/core/schedule.test.ts
@@ -15,7 +15,7 @@ import {
 
 describe("Foreground and Background operations", () => {
   const delayMs = 10;
-  const simplePlan: ActionPlan<[], Expiry, Expiry> = function* () {
+  const simplePlan: ActionPlan<Expiry, [], Expiry, [number]> = function* () {
     return yield* expire(delayMs);
   };
 
@@ -28,7 +28,7 @@ describe("Foreground and Background operations", () => {
 
   test("team() : executes inner plans in parallel to completion", async () => {
     const before = new Date().getTime();
-    const planGroup: Array<ActionPlan<[], Expiry, Expiry>> = [
+    const planGroup: Array<ActionPlan<Expiry, [], Expiry, [number]>> = [
       simplePlan,
       simplePlan,
       simplePlan,
@@ -50,7 +50,7 @@ describe("Foreground and Background operations", () => {
 
   test("backgroundAll : yields array of completion promises", async () => {
     const before = new Date().getTime();
-    const planGroup: Array<ActionPlan<[], Expiry, Expiry>> = [
+    const planGroup: Array<ActionPlan<Expiry, [], Expiry, [number]>> = [
       simplePlan,
       simplePlan,
       simplePlan,


### PR DESCRIPTION
This PR intended to retire Actions (instances having an act function) and use just ActionInvocations throughout - a data structure containing any sync or async function, along with the arguments to run it. 

I think it ran into issues related to https://stackoverflow.com/questions/67144244/when-using-a-function-as-a-first-class-value-in-typescript-is-there-a-way-to-pa where the information of a Generic function would inevitably be lost when wrapping functions. 

With a performer now a simple function that accepts an action and resolves a reaction, we would like to wrap performers to create new middleware - basically to intercept the action -> reaction step for logging or mocking or whatever. However, when trying to author these wrapping operations we'd start with a Generic function, but not be able to return a function with the same generics.

This PR seemed to get to the point that wrapping had compiled but hadn't been tested yet. However, it's so far behind the main branch at this point that it would have to be rewritten to port across any lessons. A simple merge is too hard to achieve, and it wasn't functional anyway, yet. 