### PR TITLE
Temporarily adopt Typedoc beta for 4.3. compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/modules/store-react/package.json
+++ b/modules/store-react/package.json
@@ -22,7 +22,6 @@
   "devDependencies": {
     "@testing-library/react": "^11.2.5",
     "@testing-library/user-event": "^13.1.9",
-    "typedoc": "^0.20.36",
     "typescript": "^4.3.4"
   },
   "gitHead": "03bd2f443dd739f47240c303214f24d611aa4ddc",

--- a/modules/store/package.json
+++ b/modules/store/package.json
@@ -17,7 +17,6 @@
     "immer": "^8.0.1"
   },
   "devDependencies": {
-    "typedoc": "^0.20.36",
     "typescript": "^4.3.4"
   },
   "gitHead": "03bd2f443dd739f47240c303214f24d611aa4ddc",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "ts-jest": "^26.5.2",
     "ts-loader": "^8.0.17",
     "ts-node": "^9.1.1",
+    "typedoc": ">=0.21.0-beta.2",
     "typescript": "^4.3.4",
     "webpack": "^5.24.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3967,11 +3967,6 @@ colorette@^1.2.1, colorette@^1.2.2:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
-colors@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
-  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
-
 columnify@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/columnify/-/columnify-1.5.4.tgz#4737ddf1c7b69a8a7c340570782e947eec8e78bb"
@@ -7877,10 +7872,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marked@^2.0.3:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-2.0.7.tgz#bc5b857a09071b48ce82a1f7304913a993d4b7d1"
-  integrity sha512-BJXxkuIfJchcXOJWTT2DOL+yFWifFv2yGYOUzvXg8Qz610QKw+sHCvTMYwA+qWGhlA2uivBezChZ/pBy1tWdkQ==
+marked@^2.0.7:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-2.1.1.tgz#b7c27f520fc4de0ddd049d9b4be3b04e06314923"
+  integrity sha512-5XFS69o9CzDpQDSpUYC+AN2xvq8yl1EGa5SG/GI1hP78/uTeo3PDfiDNmsUyiahpyhToDDJhQk7fNtJsga+KVw==
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -10396,7 +10391,7 @@ shell-quote@1.7.2:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
 
-shelljs@^0.8.3, shelljs@^0.8.4:
+shelljs@^0.8.3:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
   integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
@@ -11508,20 +11503,18 @@ typedoc-default-themes@^0.12.10:
   resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.12.10.tgz#614c4222fe642657f37693ea62cad4dafeddf843"
   integrity sha512-fIS001cAYHkyQPidWXmHuhs8usjP5XVJjWB8oZGqkTowZaz3v7g3KDZeeqE82FBrmkAnIBOY3jgy7lnPnqATbA==
 
-typedoc@^0.20.36:
-  version "0.20.36"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.20.36.tgz#ee5523c32f566ad8283fc732aa8ea322d1a45f6a"
-  integrity sha512-qFU+DWMV/hifQ9ZAlTjdFO9wbUIHuUBpNXzv68ZyURAP9pInjZiO4+jCPeAzHVcaBCHER9WL/+YzzTt6ZlN/Nw==
+typedoc@>=0.21.0-beta.2:
+  version "0.21.0-beta.4"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.21.0-beta.4.tgz#85fb3f16050a3302d238c923df5efbcbb754684a"
+  integrity sha512-8V5tx+QFp8CGVjXApdnZd84OBnJEWwQNHgryMfdRp9EiXo7sqP3EmeqYeaLtjE3xlQkai7RljtDX6E7n9d6v3Q==
   dependencies:
-    colors "^1.4.0"
-    fs-extra "^9.1.0"
+    glob "^7.1.6"
     handlebars "^4.7.7"
     lodash "^4.17.21"
     lunr "^2.3.9"
-    marked "^2.0.3"
+    marked "^2.0.7"
     minimatch "^3.0.0"
     progress "^2.0.3"
-    shelljs "^0.8.4"
     shiki "^0.9.3"
     typedoc-default-themes "^0.12.10"
 


### PR DESCRIPTION
Thanks to the work of gerrit0 on typedoc there is a beta which enables 4.3 compatibility and will hopefully enable the documentation publish github action to proceed after upgrading the rest of the project to Typescript 4.3.4.

The beta works locally to build the API ( https://github.com/TypeStrong/typedoc/issues/1589 ) and merging this PR should create the same environment for the main-branch's github action. 

This PR also removes typedoc from where it was previously running locally within modules in the monorepo - now hoisted to the top and accepting any version greater than the beta.

Failing run from the Node 10 version which is now beyond EOL [see run](https://github.com/cefn/lauf/pull/107/checks?check_run_id=2853145939) has prompted its removal from the test build matrix too.