### PR TITLE
Share documentation for store-follow. Minor doc improvements elsewhere.

### DIFF
--- a/apps/nextjs-snake/src/game.ts
+++ b/apps/nextjs-snake/src/game.ts
@@ -99,9 +99,9 @@ async function inputDirectionRoutine(appModel: AppModel): Promise<never> {
   const { edit, select } = gameStore;
   while (true) {
     //block for next instruction
-    const [inputDirection, active] = await receive();
-    const motionDirection = select(selectMotion);
-    const { direction: headDirection } = select(selectHead);
+    const [inputDirection, active] = await receive(); // newly instructed direction
+    const motionDirection = select(selectMotion); // direction currently moving (or undefined if still)
+    const { direction: headDirection } = select(selectHead); // direction the head is pointing
     if (active) {
       if (inputDirection === motionDirection) {
         continue; //ignore - no change needed - probably key repeat
@@ -132,18 +132,18 @@ function eatFruit(appModel: AppModel) {
   edit((state, castDraft) => {
     state.score += 1;
     state.length += 1;
-    //place new fruit outside snake
+    // place new fruit outside snake
     let nextPos = null;
     while (nextPos === null) {
-      nextPos = castDraft(randomSquare());
+      nextPos = randomSquare();
       for (const segment of state.segments) {
         if (isVectorEqual(nextPos, segment.pos)) {
-          nextPos = null; //try again
+          nextPos = null; // landed on the snake - try again
           break;
         }
       }
     }
-    state.fruitPos = nextPos;
+    state.fruitPos = castDraft(nextPos);
   });
 }
 

--- a/modules/store-follow/README.md
+++ b/modules/store-follow/README.md
@@ -1,1 +1,20 @@
+## State Management for Javascript with Typescript support.
+
 [![codecov](https://codecov.io/gh/cefn/lauf/branch/main/graph/badge.svg?token=H4O0Wmvho5&flag=store-follow)](https://codecov.io/gh/cefn/lauf)
+
+<img src="https://github.com/cefn/lauf/raw/main/vector/logo.png" alt="Logo - Image of Runner" align="left"><br></br>
+
+# Lauf Store Follow
+
+<sub><sup>Logo - Diego Naive, Noun Project.</sup></sub>
+<br></br>
+
+### Install
+
+```
+npm install @lauf/store-follow --save
+```
+
+`@lauf/store-follow` provides simple async monitoring primitives for state-management with [@lauf/store](https://www.npmjs.com/package/@lauf/store), (a simple substitute for Flux/Redux based on [Immer](https://immerjs.github.io/immer/)).
+
+Browse the [API](https://cefn.com/lauf/api/modules/_lauf_store_follow.html) or see the `followSelector` and `withSelectorQueue` primitives in the [Lauf Snake app](https://github.com/cefn/lauf/blob/main/apps/nextjs-snake/src/game.ts) example.

--- a/modules/store-follow/src/core.ts
+++ b/modules/store-follow/src/core.ts
@@ -4,7 +4,7 @@ import { Controls, Follower, QueueHandler, ExitStatus } from "./types";
 
 /**
  * Creates a queue subscribed to a [[Store]]'s [[Selector]] value then waits for
- * the duration of (possibly async) `handleQueue`. A selector queue
+ * `handleQueue` to complete (which may be async). A selector queue
  * [Queue.receive|receives] an initial message with the value calculated by the
  * [[Selector|selector]] from the [[Store|store]]. It is subscribed to receive a
  * further message whenever the selector's value changes. After `handleQueue`

--- a/modules/store-react/README.md
+++ b/modules/store-react/README.md
@@ -15,11 +15,11 @@
 npm install @lauf/store-react --save
 ```
 
-`@lauf/store-react` enables React apps to use [@lauf/store](https://github.com/cefn/lauf/tree/main/modules/store)
+`@lauf/store-react` enables React apps to use [@lauf/store](https://www.npmjs.com/package/@lauf/store)
 for state-management, providing a simple substitute for Flux/Redux based on
 [Immer](https://immerjs.github.io/immer/).
 
-Browse the [API](https://cefn.com/lauf/api) or the Typescript example inlined below from our [Counter
+Browse the [API](https://cefn.com/lauf/api/modules/_lauf_store_react.html) or the Typescript example inlined below from our [Counter
 App](https://github.com/cefn/lauf/tree/main/apps/counter).
 
 The example shows how `useSelected` can bind part of a `Store`'s state to a component,

--- a/modules/store/README.md
+++ b/modules/store/README.md
@@ -19,9 +19,11 @@ npm install @lauf/store --save
 
 It is incredibly lightweight and suitable for adoption with almost any server-side or client-side framework in Typescript or Javascript.
 
-A React binding of `@lauf/store` is provided by the [@lauf/store-react](https://www.npmjs.com/package/@lauf/store-react) package.
+Framework-independent async bindings for `@lauf/store` are provided by [@lauf/store-follow](https://www.npmjs.com/package/@lauf/store-follow).
 
-Browse the [API](https://cefn.com/lauf/api) or see the minimal JS and TS examples inlined below **_without_** React, showing how to define a new application state, track changes and make edits.
+React bindings for `@lauf/store` are provided by [@lauf/store-react](https://www.npmjs.com/package/@lauf/store-react).
+
+Browse the [API](https://cefn.com/lauf/api/modules/_lauf_store.html) or see the minimal JS and TS examples inlined below **_without_** React or Async, showing the fundamentals of defining a new application state, tracking changes and making edits.
 
 ### In Javascript
 

--- a/modules/store/src/types/immutable.ts
+++ b/modules/store/src/types/immutable.ts
@@ -1,16 +1,28 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import type { castDraft, Draft } from "immer";
 
-/** Recursive implementation of `Readonly<T>`.
+/** Recursive implementation of Typescript's `Readonly<T>`.
  *
- * Flags and enforces immutability of a [[RootState]] and its descendants for
- * values [[Store.write|assigned to]]  or [[Store.read|retrieved from]] a
- * [[Store]]. The type `Immutable<T>` is equivalent to applying `Readonly<T>` to
- * `T` and its descendant properties, telling the compiler that no change should
- * be made anywhere in a Store's state tree.
+ * Unlike some implementations of immutability this approach introduces no
+ * special objects and methods and typically doesn't require you to change your
+ * code.
  *
- * Primitive properties are already immutable by definition. Functions are treated
- * as primitive values. All other objects and arrays are processed recursively.
+ * It is used to flags and enforce immutability of a [[RootState]] and its
+ * descendants - values [[Store.write|assigned to]] or [[Store.read|retrieved
+ * from]] a [[Store]]. The type `Immutable<T>` is equivalent to applying
+ * `Readonly<T>` to `T` and its descendant properties, telling the compiler that
+ * no change should be made anywhere in a Store's state tree.
+ *
+ * Relying on Typescript's builtin `Readonly` allows the use of normal
+ * javascript values and syntax, with the exception that operations which would
+ * manipulate the item are disallowed by the compiler. Applications written in
+ * Typescript get the greatest benefit from this approach, but javascript IDEs
+ * that load typings for code-completion can also indicate violations of the
+ * `Readonly` contract.
+ *
+ * Primitive properties are already immutable by definition. Functions are
+ * treated as primitive values. All other objects and arrays have their children
+ * made `Readonly` recursively.
  *
  */
 export type Immutable<T> = T extends (...args: any[]) => any

--- a/modules/store/src/types/store.ts
+++ b/modules/store/src/types/store.ts
@@ -6,33 +6,6 @@ import { WatchableState } from "./watchable";
  * which can be changed and monitored for changes to drive an app. Make a new
  * `Store` by calling [[createStore]] with an `initialState`.
  *
- * ## Immutable State
- *
- * Never modifying the state tree means when the state or a
- * [[Selector|selected]] branch of the state is the same ***item*** as before,
- * it is guaranteed to contain all the same ***values*** as before.
- *
- * This guarantee is crucial.
- *
- * Immutability allows Watchers you write, renderers like
- * [[https://reactjs.org/|React]] and memoizers like
- * [[https://github.com/reduxjs/reselect|Reselect]] or React's
- * [useMemo()](https://reactjs.org/docs/hooks-reference.html#usememo) to use
- * 'shallow equality checking'. They can efficiently check when changes to an
- * item make it necessary to re-render or recompute - simply
- * when`Object.is(prevItem,nextItem)===false`.
- *
- * Immutability eliminates bugs and race conditions in state-change event
- * handlers. Handlers notified of a change effectively have a snapshot of state.
- * You don't have to handle cases where other code changed the state again
- * before your handler read the data. N.B. whenever you [[edit|Editor]] data,
- * you DO work with the current, not historical state, but this reconciliation
- * is unavoidable and manageable.
- *
- * Finally, Immutability establishes a basis for advanced debugging techniques such as
- * time-travel debugging since every state change notification includes a
- * momentary snapshot of the app state which can be stored indefinitely.
- *
  * ## Watching State
  *
  * Assigning a new [[Immutable]] `RootState` using [[Store.write]] notifies
@@ -49,6 +22,34 @@ import { WatchableState } from "./watchable";
  *
  * Alternatively you can construct a new `Immutable` value yourself, then
  * explicitly call [[Store.write]] to update the state.
+ *
+ * ## Immutable State: Motivation
+ *
+ * Never modifying the state tree means when the state or a
+ * [[Selector|selected]] branch of the state is the same ***item*** as before,
+ * it is guaranteed to contain all the same ***values*** as before. This
+ * guarantee is crucial.
+ *
+ * Immutability allows Watchers you write, renderers like
+ * [[https://reactjs.org/|React]] and memoizers like
+ * [[https://github.com/reduxjs/reselect|Reselect]] or React's
+ * [useMemo()](https://reactjs.org/docs/hooks-reference.html#usememo) to use
+ * 'shallow equality checking'. They can efficiently check when changes to an
+ * item should trigger a re-render or recompute - simply
+ * when`Object.is(prevItem,nextItem)===false`.
+ *
+ * Immutability eliminates bugs and race conditions in state-change event
+ * handlers. Handlers notified of a change effectively have a snapshot of state.
+ * You don't have to handle cases where other code changed the state again
+ * before your handler read the data.
+ *
+ * Finally, Immutability establishes a basis for advanced debugging techniques
+ * such as time-travel debugging since every state change notification includes
+ * a momentary snapshot of the app state which can be stored indefinitely.
+ *
+ * *Note whenever you [[Editor|edit]] data in the Store, this necessarily
+ * operates over the current, not historical state, but this reconciliation is
+ * unavoidable and manageable.*
  *
  */
 export interface Store<State extends RootState>
@@ -77,11 +78,14 @@ export type Selector<State extends RootState, Selected> = (
   state: Immutable<State>
 ) => Immutable<Selected>;
 
-/** Suitable state container for a [[Store]],
- * Includes for example Arrays, Tuples, Objects, Functions */
+/** Defines the set of possible state types for a [[Store]],
+ * usually the top level State 'container' is either an
+ * Array, Tuple, or keyed Object */
 export type RootState = object;
 
-/** A [[RootState]] which can be partitioned into a child [[RootState]] by
+/** An item satisfying type constraints of [[RootState]] but where a child item
+ * at `Key` ***also*** satisfies `RootState`. A Store with a
+ * [[PartitionableState]] can therefore be partitioned into a child [[Store]] by
  * `Key`.
  *
  * Partitioning enables hierarchy and logical isolation of a [[Store]], so that
@@ -94,6 +98,5 @@ export type RootState = object;
  * [[Watcher|Watchers]] of a child partition if the child [[RootState]] has not
  * changed, meaning no value within the child partition has changed. See
  */
-export type PartitionableState<
-  Key extends string | number | symbol
-> = RootState & { [k in Key]: RootState };
+export type PartitionableState<Key extends string | number | symbol> =
+  RootState & { [k in Key]: RootState };

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,7 +1,8 @@
 {
   "entryPoints": [
     "modules/store/src/index.ts",
-    "modules/store-react/src/index.ts"
+    "modules/store-react/src/index.ts",
+    "modules/store-follow/src/index.ts"
   ],
   "out": "api"
 }


### PR DESCRIPTION
This adds [@lauf/store-follow](https://www.npmjs.com/package/@lauf/store-follow) to the set of modules 'surfaced' in the API documentation and adds a basic README. It makes some minor text improvements elsewhere.