### PR TITLE
Scale to fit within viewport. Fix H1 margin bug.

### DIFF
--- a/apps/nextjs-snake/src/components/arena.tsx
+++ b/apps/nextjs-snake/src/components/arena.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { GRID_SPAN, StoreProps } from "../domain";
-import { SPRITE_SIDE } from "./graphics";
+import { SPRITE_SIDE, SCALE } from "./graphics";
 import { Fruit } from "./fruit";
 import { Score } from "./score";
 import { Snake } from "./snake";
@@ -10,9 +10,9 @@ export function Arena({ gameStore }: StoreProps) {
     <div
       style={{
         display: "block",
-        width: GRID_SPAN * SPRITE_SIDE,
-        height: GRID_SPAN * SPRITE_SIDE,
-        backgroundColor: "yellow",
+        width: GRID_SPAN * SPRITE_SIDE * SCALE,
+        height: GRID_SPAN * SPRITE_SIDE * SCALE,
+        backgroundColor: "yellow"
       }}
     >
       <Score {...{ gameStore }} />

--- a/apps/nextjs-snake/src/components/graphics.ts
+++ b/apps/nextjs-snake/src/components/graphics.ts
@@ -30,9 +30,13 @@ const SNAKE_SPRITE_OFFSETS = {
 
 export const SPRITE_SIDE = 64; // in px
 
+export const SCALE = 0.5;
+
 export const SPRITE_SHEET: SpriteSheet<SnakeSpriteName> = {
   // Graphics thanks to https://rembound.com/articles/creating-a-snake-game-tutorial-with-html5
   url: "./sprites.png",
+  width: 256,
+  height: 256,
   spriteWidth: SPRITE_SIDE,
   spriteHeight: SPRITE_SIDE,
   offsets: SNAKE_SPRITE_OFFSETS,

--- a/apps/nextjs-snake/src/components/sprite.tsx
+++ b/apps/nextjs-snake/src/components/sprite.tsx
@@ -1,9 +1,12 @@
 import React from "react";
 import { Immutable } from "@lauf/store";
 import { GRID_MAX, GRID_SPAN } from "../domain";
+import { SCALE } from "./graphics";
 
 export type SpriteSheet<TileName extends string> = Immutable<{
   url: string;
+  width: number;
+  height: number;
   spriteWidth: number;
   spriteHeight: number;
   offsets: {
@@ -27,8 +30,8 @@ export function posToStyle<SpriteName extends string>(
     spriteSheet: { spriteWidth, spriteHeight }
   } = spriteProps;
   return {
-    left: `${(gridX + GRID_MAX) * spriteWidth}px`,
-    top: `${(GRID_SPAN - (gridY + GRID_MAX + 1)) * spriteHeight}px` // vertical axis is inverted in browser
+    left: `${(gridX + GRID_MAX) * spriteWidth * SCALE}px`,
+    top: `${(GRID_SPAN - (gridY + GRID_MAX + 1)) * spriteHeight * SCALE}px` // vertical axis is inverted in browser
   };
 }
 
@@ -36,13 +39,14 @@ export function Sprite<SpriteName extends string>(
   spriteProps: SpriteProps<SpriteName>
 ) {
   const { spriteSheet, spriteName } = spriteProps;
-  const { spriteWidth, spriteHeight } = spriteSheet;
+  const { width, height, spriteWidth, spriteHeight } = spriteSheet;
 
   const backgroundImage = `url(${spriteSheet.url})`;
   const [offsetX, offsetY] = spriteSheet.offsets[spriteName];
-  const backgroundPosition = `${-offsetX * spriteWidth}px ${
-    -offsetY * spriteHeight
+  const backgroundPosition = `${-offsetX * spriteWidth * SCALE}px ${
+    -offsetY * spriteHeight * SCALE
   }px`;
+  const backgroundSize = `${width * SCALE}px ${height * SCALE}px`;
 
   const { left, top } = posToStyle(spriteProps);
 
@@ -55,12 +59,13 @@ export function Sprite<SpriteName extends string>(
       style={{
         display,
         position,
-        width: spriteWidth,
-        height: spriteHeight,
+        width: spriteWidth * SCALE,
+        height: spriteHeight * SCALE,
         left,
         top,
         backgroundImage,
-        backgroundPosition
+        backgroundPosition,
+        backgroundSize
       }}
     />
   );

--- a/apps/nextjs-snake/src/domain.ts
+++ b/apps/nextjs-snake/src/domain.ts
@@ -68,7 +68,7 @@ export type SegmentPosition = {
 
 // grid is defined as central (zero) square with squares in each direction
 // up to and including GRID_MAX
-export const GRID_MAX = 10;
+export const GRID_MAX = 5;
 export const GRID_SPAN = 1 + 2 * GRID_MAX;
 
 // export const gridArea = gridSpan * gridSpan;

--- a/apps/nextjs-snake/src/view.tsx
+++ b/apps/nextjs-snake/src/view.tsx
@@ -8,16 +8,16 @@ const directionMap: Record<string, Direction> = {
   ArrowLeft: "LEFT",
   ArrowUp: "UP",
   ArrowRight: "RIGHT",
-  ArrowDown: "DOWN",
+  ArrowDown: "DOWN"
 } as const;
 
 export function Game({ gameStore, inputQueue }: AppModel) {
-  //subscribe to key events, send as DirectionInput
+  // subscribe to key events, send as DirectionInput
   useEffect(() => {
     if (process.browser) {
       const keyListener = (e: KeyboardEvent) => {
         const { code, type } = e;
-        let active = type === "keydown";
+        const active = type === "keydown";
         const directionName = directionMap[code];
         if (!directionName) {
           return;
@@ -44,6 +44,9 @@ export function Game({ gameStore, inputQueue }: AppModel) {
           width: auto;
           border: 0;
           padding: 0;
+          margin: 0;
+        }
+        h1 {
           margin: 0;
         }
       `}</style>


### PR DESCRIPTION
This reduces the size of the snake arena by half (in integer terms) and then scales down all the image elements also by half, so that the whole arena can fit within a typical viewport. 

It also fixes an issue in which the H1 was introducing a margin forcing the yellow arena boundary to be offset relative to the snake.