### PR TITLE
Store follow tests

### DIFF
--- a/modules/store-follow/test/followSelector.test.ts
+++ b/modules/store-follow/test/followSelector.test.ts
@@ -1,0 +1,32 @@
+import { createStore, Immutable, Store } from "@lauf/store";
+import { Controls, followSelector } from "@lauf/store-follow";
+
+interface Location {
+  name: string;
+  distance: number;
+}
+
+interface AppState {
+  near: Location;
+  far: Location;
+}
+
+const INITIAL_STATE: Immutable<AppState> = {
+  near: { name: "London", distance: 100 },
+  far: { name: "Sydney", distance: 10000 },
+};
+
+describe("followSelector behaviour", () => {
+  test("followSelector", async () => {
+    const store = createStore(INITIAL_STATE);
+    const spy = jest.fn();
+
+    await followSelector(
+      store,
+      (state) => state.near,
+      async (location, controls) => {
+        spy(location);
+      }
+    );
+  });
+});

--- a/modules/store-follow/test/followSelector.test.ts
+++ b/modules/store-follow/test/followSelector.test.ts
@@ -1,5 +1,7 @@
-import { createStore, Immutable, Store } from "@lauf/store";
-import { Controls, followSelector } from "@lauf/store-follow";
+import { createStore, Immutable } from "@lauf/store";
+import { followSelector } from "@lauf/store-follow";
+
+import { manyTicks } from "./util";
 
 interface Location {
   name: string;
@@ -16,17 +18,153 @@ const INITIAL_STATE: Immutable<AppState> = {
   far: { name: "Sydney", distance: 10000 },
 };
 
-describe("followSelector behaviour", () => {
-  test("followSelector", async () => {
-    const store = createStore(INITIAL_STATE);
-    const spy = jest.fn();
+const timbuktu = {
+  name: "Timbuktu",
+  distance: 2000,
+};
+const beijing = {
+  name: "Beijing",
+  distance: 4000,
+};
+const manchester = {
+  name: "Manchester",
+  distance: 100,
+};
+const birmingham = {
+  name: "Birmingham",
+  distance: 100,
+};
 
-    await followSelector(
+describe("followSelector behaviour", () => {
+  test("follower called with initial value and every change", async () => {
+    const notified: Location[] = [];
+
+    const store = createStore(INITIAL_STATE);
+    followSelector(
       store,
-      (state) => state.near,
-      async (location, controls) => {
-        spy(location);
+      (state) => state.far,
+      async (far, controls) => {
+        notified.push(far);
       }
     );
+
+    store.edit((draft) => (draft.far = timbuktu));
+    store.edit((draft) => (draft.far = beijing));
+
+    await manyTicks();
+
+    expect(notified.length).toBe(3);
+    expect(notified[0]).toEqual(INITIAL_STATE.far);
+    expect(notified[1]).toEqual(timbuktu);
+    expect(notified[2]).toEqual(beijing);
+  });
+
+  test("follower not called for other state changes ", async () => {
+    const notified: Location[] = [];
+
+    const store = createStore(INITIAL_STATE);
+    followSelector(
+      store,
+      (state) => state.far,
+      async (far, controls) => {
+        notified.push(far);
+      }
+    );
+
+    store.edit((draft) => (draft.near = manchester));
+    store.edit((draft) => (draft.near = birmingham));
+
+    await manyTicks();
+
+    expect(notified.length).toBe(1);
+    expect(notified[0]).toEqual(INITIAL_STATE.far);
+  });
+
+  test("follower can exit using control object", async () => {
+    const store = createStore(INITIAL_STATE);
+    const promiseEnding = followSelector<AppState, Location, "exampleEnding">(
+      store,
+      (state) => state.far,
+      async (far, controls) => {
+        const { exit } = controls;
+        if (far === beijing) {
+          return exit("exampleEnding");
+        }
+      }
+    );
+
+    store.edit((draft) => (draft.far = timbuktu));
+    store.edit((draft) => (draft.far = beijing));
+
+    const ending = await promiseEnding;
+
+    expect(ending).toBe("exampleEnding");
+  });
+
+  test("follower returning ordinary value doesn't terminate", async () => {
+    const store = createStore(INITIAL_STATE);
+    let changeCount = 0;
+    const promiseEnding = followSelector<AppState, Location, "exampleEnding">(
+      store,
+      (state) => state.far,
+      async () => {
+        return changeCount++ as unknown as void; //force non-void return value to test logic
+      }
+    );
+
+    store.edit((draft) => (draft.far = timbuktu));
+    store.edit((draft) => (draft.far = beijing));
+
+    await manyTicks();
+
+    // follower has handled all changes
+    expect(changeCount).toBe(3);
+
+    //promiseEnding not resolved yet - followSelector still running
+    const winner = await Promise.race([promiseEnding, Promise.resolve()]);
+    expect(typeof winner === "undefined");
+  });
+
+  test("follower can access lastSelected()", async () => {
+    const store = createStore(INITIAL_STATE);
+    const lastSelectedValues: (Location | undefined)[] = [];
+    followSelector<AppState, Location, "exampleEnding">(
+      store,
+      (state) => state.far,
+      async (far, controls) => {
+        const { lastSelected } = controls;
+        const lastSelectedValue = lastSelected();
+        lastSelectedValues.push(lastSelectedValue);
+      }
+    );
+
+    store.edit((draft) => (draft.far = timbuktu));
+    store.edit((draft) => (draft.far = beijing));
+
+    await manyTicks();
+
+    expect(lastSelectedValues).toEqual([
+      undefined,
+      INITIAL_STATE.far,
+      timbuktu,
+    ]);
+  });
+
+  test("follower throwing terminates implicit loop", async () => {
+    const store = createStore(INITIAL_STATE);
+    let error;
+    try {
+      await followSelector<AppState, Location, "exampleEnding">(
+        store,
+        (state) => state.far,
+        async () => {
+          throw new Error("I am terminating");
+        }
+      );
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe("I am terminating");
   });
 });

--- a/modules/store-follow/test/util.ts
+++ b/modules/store-follow/test/util.ts
@@ -1,0 +1,6 @@
+export async function manyTicks() {
+  // wait for multiple ticks
+  for (let countdown = 100; countdown-- > 0; ) {
+    await Promise.resolve();
+  }
+}

--- a/modules/store-follow/test/withSelectorQueue.test.ts
+++ b/modules/store-follow/test/withSelectorQueue.test.ts
@@ -1,4 +1,119 @@
+import { createStore, Immutable } from "@lauf/store";
 import { withSelectorQueue } from "@lauf/store-follow";
+
+import { manyTicks } from "./util";
+
+interface Location {
+  name: string;
+  distance: number;
+}
+
+interface AppState {
+  near: Location;
+  far: Location;
+}
+
+const INITIAL_STATE: Immutable<AppState> = {
+  near: { name: "London", distance: 100 },
+  far: { name: "Sydney", distance: 10000 },
+};
+
+const timbuktu = {
+  name: "Timbuktu",
+  distance: 2000,
+};
+const beijing = {
+  name: "Beijing",
+  distance: 4000,
+};
+const manchester = {
+  name: "Manchester",
+  distance: 100,
+};
+const birmingham = {
+  name: "Birmingham",
+  distance: 100,
+};
+
 describe("withSelectorQueue behaviour", () => {
-  test("withSelectorQueue", async () => {});
+  test("withSelectorQueue passes a queue notifying selected changes", async () => {
+    const store = createStore(INITIAL_STATE);
+
+    const notified: Location[] = [];
+
+    withSelectorQueue(
+      store,
+      (state) => state.near,
+      async (queue, initialValue) => {
+        let near = initialValue;
+        while (true) {
+          notified.push(near);
+          near = await queue.receive();
+        }
+      }
+    );
+    store.edit((draft) => (draft.near = birmingham));
+    store.edit((draft) => (draft.near = manchester));
+
+    await manyTicks();
+    expect(notified.length).toBe(3);
+    expect(notified[0]).toBe(INITIAL_STATE.near);
+    expect(notified[1]).toBe(birmingham);
+    expect(notified[2]).toBe(manchester);
+  });
+
+  test("withSelectorQueue doesn't receive again when selected is identical", async () => {
+    const store = createStore(INITIAL_STATE);
+
+    const notified: Location[] = [];
+
+    withSelectorQueue(
+      store,
+      (state) => state.near,
+      async (queue, initialValue) => {
+        let near = initialValue;
+        while (true) {
+          notified.push(near);
+          near = await queue.receive();
+        }
+      }
+    );
+    store.edit((draft) => (draft.near = INITIAL_STATE.near));
+
+    await manyTicks();
+    expect(notified.length).toBe(1);
+    expect(notified[0]).toBe(INITIAL_STATE.near);
+  });
+
+  test("withSelectorQueue queueHandler can return a value", async () => {
+    const store = createStore(INITIAL_STATE);
+
+    const notified: Location[] = [];
+
+    const promiseEnding = withSelectorQueue(
+      store,
+      (state) => state.near,
+      async (queue, initialValue) => {
+        let near = initialValue;
+        while (true) {
+          notified.push(near);
+          near = await queue.receive();
+          if (near === manchester) {
+            return manchester;
+          }
+        }
+      }
+    );
+
+    store.edit((draft) => (draft.near = birmingham));
+    store.edit((draft) => (draft.near = manchester));
+
+    await manyTicks();
+    expect(notified.length).toBe(2);
+    expect(notified[0]).toBe(INITIAL_STATE.near);
+    expect(notified[1]).toBe(birmingham);
+
+    const ending = await promiseEnding;
+    expect(ending).toBe(manchester);
+  });
 });

--- a/modules/store-follow/test/withSelectorQueue.test.ts
+++ b/modules/store-follow/test/withSelectorQueue.test.ts
@@ -1,0 +1,4 @@
+import { withSelectorQueue } from "@lauf/store-follow";
+describe("withSelectorQueue behaviour", () => {
+  test("withSelectorQueue", async () => {});
+});


### PR DESCRIPTION
Introduces illustrative tests for `followSelector` and `withSelectorQueue` taking the store-follow package to 100% coverage.