### PR TITLE
Pin pnpm to version 6

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           node-version: 14.x
       - name: Install PNPM
-        run: npm install -g pnpm
+        run: npm install -g pnpm@6
       - run: pnpm install
       - run: cd modules/${{matrix.module-name}} && pnpm run test
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: 14.x
       - name: Install PNPM
-        run: npm install -g pnpm
+        run: npm install -g pnpm@6
       - run: pnpm install
       - run: pnpm run validate
       - run: pnpm run check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install PNPM
-        run: npm install -g pnpm
+        run: npm install -g pnpm@6
       - run: pnpm install
       - run: pnpm run validate
       - run: pnpm run check:lauf


### PR DESCRIPTION
Probably fixes CI builds by pinning to pnpm@6 (somehow the implicit install of a more recent pnpm version leads to Typescript resolution errors).

