### PR TITLE
Release 1.1.0 alpha

### DIFF
--- a/.changeset/moody-flowers-poke.md
+++ b/.changeset/moody-flowers-poke.md
@@ -1,0 +1,9 @@
+---
+"@lauf/lock": minor
+"@lauf/queue": minor
+"@lauf/store": minor
+"@lauf/store-follow": minor
+"@lauf/store-react": minor
+---
+
+Align and test with Typescript 4.8, Jest 29, Next 12 etc.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -16,5 +16,7 @@
     "@lauf/store-follow": "1.0.1",
     "@lauf/store-react": "1.0.1"
   },
-  "changesets": []
+  "changesets": [
+    "moody-flowers-poke"
+  ]
 }

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,20 @@
+{
+  "mode": "pre",
+  "tag": "alpha",
+  "initialVersions": {
+    "counter": "0.1.6",
+    "nextjs-mixer": "0.1.6",
+    "nextjs-mornington": "0.1.4",
+    "next-snake": "0.1.6",
+    "noredux-async": "0.1.5",
+    "@lauf/lauf-runner": "0.1.2",
+    "@lauf/lauf-runner-primitives": "0.1.5",
+    "@lauf/lauf-runner-trial": "0.1.2",
+    "@lauf/lock": "1.0.1",
+    "@lauf/queue": "1.0.1",
+    "@lauf/store": "1.0.1",
+    "@lauf/store-follow": "1.0.1",
+    "@lauf/store-react": "1.0.1"
+  },
+  "changesets": []
+}

--- a/apps/counter/CHANGELOG.md
+++ b/apps/counter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # counter
 
+## 0.1.7-alpha.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @lauf/store@1.1.0-alpha.0
+  - @lauf/store-react@1.1.0-alpha.0
+
 ## 0.1.6
 
 ### Patch Changes

--- a/apps/counter/package.json
+++ b/apps/counter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "counter",
-  "version": "0.1.6",
+  "version": "0.1.7-alpha.0",
   "main": "index.js",
   "license": "MIT",
   "scripts": {
@@ -93,8 +93,8 @@
   "author": "Cefn Hoile <github.com@cefn.com> (https://cefn.com)",
   "repository": "github:cefn/lauf",
   "dependencies": {
-    "@lauf/store": "^1.0.1",
-    "@lauf/store-react": "^1.0.1",
+    "@lauf/store": "^1.1.0-alpha.0",
+    "@lauf/store-react": "^1.1.0-alpha.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }

--- a/apps/nextjs-mixer/CHANGELOG.md
+++ b/apps/nextjs-mixer/CHANGELOG.md
@@ -1,5 +1,13 @@
 # nextjs-mixer
 
+## 0.1.7-alpha.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @lauf/store@1.1.0-alpha.0
+  - @lauf/store-react@1.1.0-alpha.0
+
 ## 0.1.6
 
 ### Patch Changes

--- a/apps/nextjs-mixer/package.json
+++ b/apps/nextjs-mixer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs-mixer",
-  "version": "0.1.6",
+  "version": "0.1.7-alpha.0",
   "private": true,
   "scripts": {
     "dev": "NODE_OPTIONS='--inspect' next dev",
@@ -10,8 +10,8 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@lauf/store": "^1.0.1",
-    "@lauf/store-react": "^1.0.1",
+    "@lauf/store": "^1.1.0-alpha.0",
+    "@lauf/store-react": "^1.1.0-alpha.0",
     "next": "^12.3.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/apps/nextjs-snake/CHANGELOG.md
+++ b/apps/nextjs-snake/CHANGELOG.md
@@ -1,5 +1,15 @@
 # next-snake
 
+## 0.1.7-alpha.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @lauf/queue@1.1.0-alpha.0
+  - @lauf/store@1.1.0-alpha.0
+  - @lauf/store-follow@1.1.0-alpha.0
+  - @lauf/store-react@1.1.0-alpha.0
+
 ## 0.1.6
 
 ### Patch Changes

--- a/apps/nextjs-snake/package.json
+++ b/apps/nextjs-snake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-snake",
-  "version": "0.1.6",
+  "version": "0.1.7-alpha.0",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -11,10 +11,10 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@lauf/queue": "^1.0.1",
-    "@lauf/store": "^1.0.1",
-    "@lauf/store-follow": "^1.0.1",
-    "@lauf/store-react": "^1.0.1",
+    "@lauf/queue": "^1.1.0-alpha.0",
+    "@lauf/store": "^1.1.0-alpha.0",
+    "@lauf/store-follow": "^1.1.0-alpha.0",
+    "@lauf/store-react": "^1.1.0-alpha.0",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/apps/noredux-async/CHANGELOG.md
+++ b/apps/noredux-async/CHANGELOG.md
@@ -1,5 +1,14 @@
 # noredux-async
 
+## 0.1.6-alpha.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @lauf/store@1.1.0-alpha.0
+  - @lauf/store-follow@1.1.0-alpha.0
+  - @lauf/store-react@1.1.0-alpha.0
+
 ## 0.1.5
 
 ### Patch Changes

--- a/apps/noredux-async/package.json
+++ b/apps/noredux-async/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noredux-async",
-  "version": "0.1.5",
+  "version": "0.1.6-alpha.0",
   "main": "index.js",
   "license": "MIT",
   "scripts": {
@@ -86,9 +86,9 @@
     }
   },
   "dependencies": {
-    "@lauf/store": "^1.0.1",
-    "@lauf/store-follow": "^1.0.1",
-    "@lauf/store-react": "^1.0.1",
+    "@lauf/store": "^1.1.0-alpha.0",
+    "@lauf/store-follow": "^1.1.0-alpha.0",
+    "@lauf/store-react": "^1.1.0-alpha.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }

--- a/modules/lauf-runner-primitives/CHANGELOG.md
+++ b/modules/lauf-runner-primitives/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @lauf/lauf-runner-primitives
 
+## 0.1.6-alpha.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @lauf/queue@1.1.0-alpha.0
+  - @lauf/store@1.1.0-alpha.0
+
 ## 0.1.5
 
 ### Patch Changes

--- a/modules/lauf-runner-primitives/package.json
+++ b/modules/lauf-runner-primitives/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lauf/lauf-runner-primitives",
-  "version": "0.1.5",
+  "version": "0.1.6-alpha.0",
   "private": true,
   "license": "MIT",
   "scripts": {
@@ -18,8 +18,8 @@
   ],
   "dependencies": {
     "@lauf/lauf-runner": "workspace:^0.1.2",
-    "@lauf/queue": "^1.0.1",
-    "@lauf/store": "^1.0.1"
+    "@lauf/queue": "^1.1.0-alpha.0",
+    "@lauf/store": "^1.1.0-alpha.0"
   },
   "gitHead": "03bd2f443dd739f47240c303214f24d611aa4ddc",
   "publishConfig": {

--- a/modules/lock/CHANGELOG.md
+++ b/modules/lock/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lauf/lock
 
+## 1.1.0-alpha.0
+
+### Minor Changes
+
+- Align and test with Typescript 4.8, Jest 29, Next 12 etc.
+
 ## 1.0.1
 
 ### Patch Changes

--- a/modules/lock/package.json
+++ b/modules/lock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lauf/lock",
-  "version": "1.0.1",
+  "version": "1.1.0-alpha.0",
   "license": "MIT",
   "scripts": {
     "test": "jest",

--- a/modules/queue/CHANGELOG.md
+++ b/modules/queue/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lauf/queue
 
+## 1.1.0-alpha.0
+
+### Minor Changes
+
+- Align and test with Typescript 4.8, Jest 29, Next 12 etc.
+
 ## 1.0.1
 
 ### Patch Changes

--- a/modules/queue/package.json
+++ b/modules/queue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lauf/queue",
-  "version": "1.0.1",
+  "version": "1.1.0-alpha.0",
   "license": "MIT",
   "scripts": {
     "test": "jest",

--- a/modules/store-follow/CHANGELOG.md
+++ b/modules/store-follow/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @lauf/store-follow
 
+## 1.1.0-alpha.0
+
+### Minor Changes
+
+- Align and test with Typescript 4.8, Jest 29, Next 12 etc.
+
+### Patch Changes
+
+- Updated dependencies
+  - @lauf/queue@1.1.0-alpha.0
+  - @lauf/store@1.1.0-alpha.0
+
 ## 1.0.1
 
 ### Patch Changes

--- a/modules/store-follow/package.json
+++ b/modules/store-follow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lauf/store-follow",
-  "version": "1.0.1",
+  "version": "1.1.0-alpha.0",
   "license": "MIT",
   "scripts": {
     "test": "jest --passWithNoTests",
@@ -66,8 +66,8 @@
     }
   },
   "dependencies": {
-    "@lauf/queue": "^1.0.1",
-    "@lauf/store": "^1.0.1"
+    "@lauf/queue": "^1.1.0-alpha.0",
+    "@lauf/store": "^1.1.0-alpha.0"
   },
   "main": "src/index.ts"
 }

--- a/modules/store-react/CHANGELOG.md
+++ b/modules/store-react/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @lauf/store-react
 
+## 1.1.0-alpha.0
+
+### Minor Changes
+
+- Align and test with Typescript 4.8, Jest 29, Next 12 etc.
+
+### Patch Changes
+
+- Updated dependencies
+  - @lauf/store@1.1.0-alpha.0
+
 ## 1.0.1
 
 ### Patch Changes

--- a/modules/store-react/package.json
+++ b/modules/store-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lauf/store-react",
   "description": "State Management for React with Typescript support.",
-  "version": "1.0.1",
+  "version": "1.1.0-alpha.0",
   "files": [
     "README.md",
     "dist"
@@ -14,7 +14,7 @@
     "prepublishOnly": "pnpm run test && pnpm run build"
   },
   "dependencies": {
-    "@lauf/store": "^1.0.1"
+    "@lauf/store": "^1.1.0-alpha.0"
   },
   "peerDependencies": {
     "react": "^18.2.0"

--- a/modules/store/CHANGELOG.md
+++ b/modules/store/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lauf/store
 
+## 1.1.0-alpha.0
+
+### Minor Changes
+
+- Align and test with Typescript 4.8, Jest 29, Next 12 etc.
+
 ## 1.0.1
 
 ### Patch Changes

--- a/modules/store/package.json
+++ b/modules/store/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lauf/store",
   "description": "State Management for Javascript with Typescript support.",
-  "version": "1.0.1",
+  "version": "1.1.0-alpha.0",
   "files": [
     "README.md",
     "dist"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "check:changed": "pnpm recursive run check --filter '...[origin/main]...'",
     "check:lauf": "pnpm recursive run check --filter '@lauf/*'",
     "validate": "ts-node-esm ./validate-packages.ts",
-    "release": "pnpx changeset add && git add && git commit -a && pnpx changeset version && pnpm install && pnpm publish -r",
+    "release": "pnpx changeset add && pnpx changeset version && git add . && git commit -a && pnpm install --frozen-lockfile && pnpm recursive publish",
     "docs": "typedoc --tsconfig tsconfig.typedoc.json --includes ./ --out api",
     "docs:watch": "pnpm run docs -- --watch",
     "docs:serve": "reload -d api",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,8 +106,8 @@ importers:
       '@babel/core': ^7.19.1
       '@babel/preset-env': ^7.19.1
       '@babel/preset-react': ^7.18.6
-      '@lauf/store': ^1.0.1
-      '@lauf/store-react': ^1.0.1
+      '@lauf/store': ^1.1.0-alpha.0
+      '@lauf/store-react': ^1.1.0-alpha.0
       '@playwright/test': ^1.26.0
       '@types/react': ^18.0.21
       '@types/react-dom': ^18.0.6
@@ -154,8 +154,8 @@ importers:
 
   apps/nextjs-mixer:
     specifiers:
-      '@lauf/store': ^1.0.1
-      '@lauf/store-react': ^1.0.1
+      '@lauf/store': ^1.1.0-alpha.0
+      '@lauf/store-react': ^1.1.0-alpha.0
       '@types/styled-components': ^5.1.26
       next: ^12.3.1
       react: 18.2.0
@@ -203,10 +203,10 @@ importers:
       '@babel/core': ^7.19.1
       '@babel/preset-env': ^7.19.1
       '@babel/preset-typescript': ^7.18.6
-      '@lauf/queue': ^1.0.1
-      '@lauf/store': ^1.0.1
-      '@lauf/store-follow': ^1.0.1
-      '@lauf/store-react': ^1.0.1
+      '@lauf/queue': ^1.1.0-alpha.0
+      '@lauf/store': ^1.1.0-alpha.0
+      '@lauf/store-follow': ^1.1.0-alpha.0
+      '@lauf/store-react': ^1.1.0-alpha.0
       '@testing-library/react': ^13.4.0
       '@types/jest': ^29.0.3
       '@types/react': ^18.0.21
@@ -254,9 +254,9 @@ importers:
       '@babel/core': ^7.19.1
       '@babel/preset-env': ^7.19.1
       '@babel/preset-react': ^7.18.6
-      '@lauf/store': ^1.0.1
-      '@lauf/store-follow': ^1.0.1
-      '@lauf/store-react': ^1.0.1
+      '@lauf/store': ^1.1.0-alpha.0
+      '@lauf/store-follow': ^1.1.0-alpha.0
+      '@lauf/store-react': ^1.1.0-alpha.0
       '@types/react': ^18.0.21
       '@types/react-dom': ^18.0.6
       babel-loader: ^8.2.5
@@ -305,8 +305,8 @@ importers:
   modules/lauf-runner-primitives:
     specifiers:
       '@lauf/lauf-runner': workspace:^0.1.2
-      '@lauf/queue': ^1.0.1
-      '@lauf/store': ^1.0.1
+      '@lauf/queue': ^1.1.0-alpha.0
+      '@lauf/store': ^1.1.0-alpha.0
       typescript: ^4.8.3
     dependencies:
       '@lauf/lauf-runner': link:../lauf-runner
@@ -349,8 +349,8 @@ importers:
 
   modules/store-follow:
     specifiers:
-      '@lauf/queue': ^1.0.1
-      '@lauf/store': ^1.0.1
+      '@lauf/queue': ^1.1.0-alpha.0
+      '@lauf/store': ^1.1.0-alpha.0
       typescript: ^4.8.3
     dependencies:
       '@lauf/queue': link:../queue
@@ -360,7 +360,7 @@ importers:
 
   modules/store-react:
     specifiers:
-      '@lauf/store': ^1.0.1
+      '@lauf/store': ^1.1.0-alpha.0
       '@testing-library/dom': ^8.18.1
       '@testing-library/react': ^13.4.0
       '@testing-library/user-event': ^14.4.3
@@ -12602,7 +12602,7 @@ packages:
       schema-utils: 3.1.1
       serialize-javascript: 6.0.0
       terser: 5.15.0
-      webpack: 5.74.0
+      webpack: 5.74.0_webpack-cli@4.10.0
     dev: true
 
   /terser/5.15.0:
@@ -12756,7 +12756,7 @@ packages:
       micromatch: 4.0.5
       semver: 7.3.7
       typescript: 4.8.3
-      webpack: 5.74.0
+      webpack: 5.74.0_webpack-cli@4.10.0
     dev: true
 
   /ts-node/10.9.1_typescript@4.8.3:


### PR DESCRIPTION
I published the alpha version of 1.1.0 from this commit. It includes all the updates for alignment with Typescript 4.8, Jest 29, Next 12 and every other npm upgrade.