### PR TITLE
Fix bundle

### DIFF
--- a/.changeset/popular-sheep-press.md
+++ b/.changeset/popular-sheep-press.md
@@ -1,0 +1,9 @@
+---
+"@lauf/lock": patch
+"@lauf/queue": patch
+"@lauf/store": patch
+"@lauf/store-follow": patch
+"@lauf/store-react": patch
+---
+
+Fixes a bundling issue which caused deps to be included.

--- a/esbuild.base.cjs
+++ b/esbuild.base.cjs
@@ -1,17 +1,21 @@
 const path = require("path");
 const { build } = require("esbuild");
-const { dependencies, peerDependencies } = require("./package.json");
-
-const external = [];
-if (dependencies) {
-  external.push(Object.keys(dependencies));
-}
-if (peerDependencies) {
-  external.push(Object.keys(peerDependencies));
-}
 
 module.exports = {
   doBuild(modulePath) {
+    const { dependencies, peerDependencies } = require(path.resolve(
+      modulePath,
+      "./package.json"
+    ));
+
+    let external = [];
+    if (dependencies) {
+      external = external.concat(Object.keys(dependencies));
+    }
+    if (peerDependencies) {
+      external = external.concat(Object.keys(peerDependencies));
+    }
+
     build({
       entryPoints: [path.resolve(modulePath, "src/index.ts")],
       outdir: path.resolve(modulePath, "dist"),


### PR DESCRIPTION
This resolves an issue which arrived as part of 1.1.0 esbuild changes whereby the package.json that was being considered was the top-level one (not the module one) and the population of the 'external' definition in esbuild (telling it what NOT to bundle) was therefore fumbled.