### PR TITLE
Remove edit from relevant tests

### DIFF
--- a/modules/store-follow/test/followSelector.test.ts
+++ b/modules/store-follow/test/followSelector.test.ts
@@ -1,4 +1,4 @@
-import { createStore, Immutable } from "@lauf/store";
+import { createStore, Immutable, Store } from "@lauf/store";
 import { followSelector } from "@lauf/store-follow";
 
 import { manyTicks } from "./util";
@@ -48,8 +48,14 @@ describe("followSelector behaviour", () => {
       }
     );
 
-    store.edit((draft) => (draft.far = timbuktu));
-    store.edit((draft) => (draft.far = beijing));
+    store.write({
+      ...store.read(),
+      far: timbuktu,
+    });
+    store.write({
+      ...store.read(),
+      far: beijing,
+    });
 
     await manyTicks();
 
@@ -71,8 +77,14 @@ describe("followSelector behaviour", () => {
       }
     );
 
-    store.edit((draft) => (draft.near = manchester));
-    store.edit((draft) => (draft.near = birmingham));
+    store.write({
+      ...store.read(),
+      near: manchester,
+    });
+    store.write({
+      ...store.read(),
+      near: birmingham,
+    });
 
     await manyTicks();
 
@@ -93,8 +105,14 @@ describe("followSelector behaviour", () => {
       }
     );
 
-    store.edit((draft) => (draft.far = timbuktu));
-    store.edit((draft) => (draft.far = beijing));
+    store.write({
+      ...store.read(),
+      far: timbuktu,
+    });
+    store.write({
+      ...store.read(),
+      far: beijing,
+    });
 
     const ending = await promiseEnding;
 
@@ -112,8 +130,14 @@ describe("followSelector behaviour", () => {
       }
     );
 
-    store.edit((draft) => (draft.far = timbuktu));
-    store.edit((draft) => (draft.far = beijing));
+    store.write({
+      ...store.read(),
+      far: timbuktu,
+    });
+    store.write({
+      ...store.read(),
+      far: beijing,
+    });
 
     await manyTicks();
 
@@ -138,8 +162,14 @@ describe("followSelector behaviour", () => {
       }
     );
 
-    store.edit((draft) => (draft.far = timbuktu));
-    store.edit((draft) => (draft.far = beijing));
+    store.write({
+      ...store.read(),
+      far: timbuktu,
+    });
+    store.write({
+      ...store.read(),
+      far: beijing,
+    });
 
     await manyTicks();
 

--- a/modules/store-follow/test/withSelectorQueue.test.ts
+++ b/modules/store-follow/test/withSelectorQueue.test.ts
@@ -1,4 +1,4 @@
-import { createStore, Immutable } from "@lauf/store";
+import { createStore, Immutable, Store } from "@lauf/store";
 import { withSelectorQueue } from "@lauf/store-follow";
 
 import { manyTicks } from "./util";
@@ -17,6 +17,14 @@ const INITIAL_STATE: Immutable<AppState> = {
   near: { name: "London", distance: 100 },
   far: { name: "Sydney", distance: 10000 },
 };
+
+function setNear(store: Store<AppState>, near: Location) {
+  const state = store.read();
+  store.write({
+    ...state,
+    near,
+  });
+}
 
 const timbuktu = {
   name: "Timbuktu",
@@ -52,8 +60,14 @@ describe("withSelectorQueue behaviour", () => {
         }
       }
     );
-    store.edit((draft) => (draft.near = birmingham));
-    store.edit((draft) => (draft.near = manchester));
+    store.write({
+      ...store.read(),
+      near: birmingham,
+    });
+    store.write({
+      ...store.read(),
+      near: manchester,
+    });
 
     await manyTicks();
     expect(notified.length).toBe(3);
@@ -78,7 +92,12 @@ describe("withSelectorQueue behaviour", () => {
         }
       }
     );
-    store.edit((draft) => (draft.near = INITIAL_STATE.near));
+
+    const { near } = INITIAL_STATE;
+    store.write({
+      ...store.read(),
+      near,
+    });
 
     await manyTicks();
     expect(notified.length).toBe(1);
@@ -105,8 +124,14 @@ describe("withSelectorQueue behaviour", () => {
       }
     );
 
-    store.edit((draft) => (draft.near = birmingham));
-    store.edit((draft) => (draft.near = manchester));
+    store.write({
+      ...store.read(),
+      near: birmingham,
+    });
+    store.write({
+      ...store.read(),
+      near: manchester,
+    });
 
     await manyTicks();
     expect(notified.length).toBe(2);

--- a/modules/store/src/core/partition.ts
+++ b/modules/store/src/core/partition.ts
@@ -46,10 +46,12 @@ class DefaultStorePartition<
   };
 
   write = (state: Immutable<ParentState[Key]>) => {
-    this.store.edit((draft) => {
-      (draft as any)[this.key] = state as any;
+    const parentState = this.store.read();
+    this.store.write({
+      ...parentState,
+      [this.key]: state,
     });
-    return this.read();
+    return state;
   };
 
   edit = (editor: Editor<ParentState[Key]>) => {

--- a/modules/store/test/core/partition.test.ts
+++ b/modules/store/test/core/partition.test.ts
@@ -70,8 +70,14 @@ describe("Parent Stores and Child Store Partitions", () => {
     const { deferred, deferredResolve } = createDeferredMock<ChildState>();
     const { parentStore, childStore } = createPartitionedStores();
     childStore.watch(deferredResolve);
-    parentStore.edit((draft) => {
-      draft.partition.roses = "white";
+    // set a deep value
+    const parentState = parentStore.read();
+    parentStore.write({
+      ...parentState,
+      partition: {
+        ...parentState["partition"],
+        roses: "white",
+      },
     });
     expect(await deferred).toBe(childStore.read());
   });
@@ -80,8 +86,14 @@ describe("Parent Stores and Child Store Partitions", () => {
     const watcher = jest.fn();
     const { parentStore, childStore } = createPartitionedStores();
     childStore.watch(watcher);
-    parentStore.edit((draft) => {
-      draft.other.violets = "purple";
+    // set a deep value
+    const parentState = parentStore.read();
+    parentStore.write({
+      ...parentState,
+      other: {
+        ...parentState["other"],
+        violets: "purple",
+      },
     });
     await new Promise((resolve) => setTimeout(resolve, 10));
     expect(watcher).toHaveBeenCalledTimes(0);
@@ -91,7 +103,12 @@ describe("Parent Stores and Child Store Partitions", () => {
     const { deferred, deferredResolve } = createDeferredMock<ParentState>();
     const { parentStore, childStore } = createPartitionedStores();
     parentStore.watch(deferredResolve);
-    childStore.edit((draft) => (draft.roses = "white"));
+    // set a deep value
+    const childState = childStore.read();
+    childStore.write({
+      ...childState,
+      roses: "white",
+    });
     expect(await deferred).toBe(parentStore.read());
   });
 


### PR DESCRIPTION
Transitions those tests that relate to state change to use write instead of edit, to allow removal of Immer from core.