### PR TITLE
Remove immer from core

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,8 @@ jobs:
 
     strategy:
       matrix:
-        module-name: [store, store-react, store-follow, queue, lock]
+        module-name:
+          [store, store-react, store-edit, store-follow, queue, lock]
 
     steps:
       - uses: actions/checkout@master

--- a/apps/nextjs-snake/src/logic.ts
+++ b/apps/nextjs-snake/src/logic.ts
@@ -87,12 +87,11 @@ async function stepWhileMoving(
 
 async function fruitRoutine(appModel: Model) {
   const { gameStore } = appModel;
-  const { select } = gameStore;
   await followSelector(
     gameStore,
     selectHead,
     async function (head): Promise<void> {
-      const fruitPos = select(selectFruitPos);
+      const fruitPos = selectFruitPos(gameStore.read());
       if (isVectorEqual(fruitPos, head.pos)) {
         eatFruit(appModel);
       }
@@ -156,12 +155,11 @@ function eatFruit({ gameStore }: Model) {
 
 async function snakeCollisionRoutine(appModel: Model) {
   const { gameStore } = appModel;
-  const { select } = gameStore;
   await followSelector(
     gameStore,
     selectHead,
     async function (head): Promise<void> {
-      const segments = select(selectSegments);
+      const segments = selectSegments(gameStore.read());
       for (const segment of segments) {
         if (segment !== head && isVectorEqual(head.pos, segment.pos)) {
           resetGame(appModel);
@@ -172,10 +170,8 @@ async function snakeCollisionRoutine(appModel: Model) {
 }
 
 function stepSnake(appModel: Model, direction: Direction) {
-  const {
-    gameStore: { select },
-  } = appModel;
-  const head = select(selectHead);
+  const { gameStore } = appModel;
+  const head = selectHead(gameStore.read());
   if (head) {
     const pos = wrap(plus(head.pos, DIRECTION_VECTORS[direction]));
     addHead(appModel, { pos, direction });

--- a/modules/queue/package.json
+++ b/modules/queue/package.json
@@ -15,7 +15,6 @@
     "README.md",
     "dist"
   ],
-  "gitHead": "03bd2f443dd739f47240c303214f24d611aa4ddc",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.js",

--- a/modules/store-edit/CHANGELOG.md
+++ b/modules/store-edit/CHANGELOG.md
@@ -1,0 +1,72 @@
+# @lauf/store
+
+## 1.1.1
+
+### Patch Changes
+
+- d21ec94: Fixes a bundling issue which caused deps to be included.
+
+## 1.1.0
+
+### Minor Changes
+
+- ba8de9a: Align and test with Typescript 4.8, Jest 29, Next 12 etc.
+
+### Patch Changes
+
+- 5c7cd0a: Adopt esbuild for bundling.
+
+## 1.1.0-alpha.1
+
+### Patch Changes
+
+- Adopt esbuild for bundling.
+
+## 1.1.0-alpha.0
+
+### Minor Changes
+
+- Align and test with Typescript 4.8, Jest 29, Next 12 etc.
+
+## 1.0.1
+
+### Patch Changes
+
+- 3efbd96: Improved documentation
+
+## 1.0.0
+
+### Major Changes
+
+- 4448f95: Release 1.0.0 for all @lauf modules.
+
+## 0.2.4
+
+### Patch Changes
+
+- 3a53ce1: Finalise and publish lock, queue, store-follow and their docs. Add tests for store-follow.
+
+## 0.2.3
+
+### Patch Changes
+
+- 6f55e19: Update main and typings for modules
+
+## 0.2.2
+
+### Patch Changes
+
+- b72aca2: Remove incorrect typings field
+
+## 0.2.1
+
+### Patch Changes
+
+- Patch bump to differentiate monorepo packages
+
+## 0.2.0
+
+### Minor Changes
+
+- f9a19c9: First attempted pnpm publish.
+- b25d892: Defining a changeset with a minor bump version.

--- a/modules/store-edit/README.md
+++ b/modules/store-edit/README.md
@@ -1,0 +1,76 @@
+## Lightweight Application State Management
+
+[![codecov](https://codecov.io/gh/cefn/lauf/branch/main/graph/badge.svg?token=H4O0Wmvho5&flag=store)](https://codecov.io/gh/cefn/lauf)
+
+<img src="https://github.com/cefn/lauf/raw/main/vector/logo.png" alt="Logo - Image of Runner" align="left"><br></br>
+
+# Lauf Store
+
+<sub><sup>Logo - Diego Naive, Noun Project.</sup></sub>
+<br></br>
+
+### Install
+
+```
+npm install @lauf/store --save
+```
+
+`@lauf/store` provides a minimal reactive state-management solution, a simple substitute for Flux/Redux based on [Immer](https://immerjs.github.io/immer/).
+
+It is incredibly lightweight and suitable for adoption with almost any server-side or client-side framework in Typescript or Javascript.
+
+Framework-independent async bindings for `@lauf/store` are provided by [@lauf/store-follow](https://www.npmjs.com/package/@lauf/store-follow).
+
+React bindings for `@lauf/store` are provided by [@lauf/store-react](https://www.npmjs.com/package/@lauf/store-react).
+
+Browse the [API](https://cefn.com/lauf/api/modules/_lauf_store.html) or see the minimal JS and TS examples inlined below **_without_** React or Async, showing the fundamentals of defining a new application state, tracking changes and making edits.
+
+### In Javascript
+
+```javascript
+const { createStore } = require("@lauf/store");
+
+// Create and initialize a store
+const store = createStore({
+  roses: "red",
+  violets: "blue",
+});
+
+// Watch for changes
+store.watch(console.log);
+
+// Change the color - this change will automatically call console.log in the next tick, producing
+// { roses: 'white', violets: 'blue' }
+store.edit((draft) => {
+  draft.roses = "white";
+});
+```
+
+### In Typescript
+
+```typescript
+import { createStore, Immutable } from "@lauf/store";
+
+// Define a type for Store state
+export type AppState = Record<string, string>;
+
+// Define the initial Store state
+const INITIAL_STATE: Immutable<AppState> = {
+  roses: "red",
+  violets: "blue",
+} as const;
+
+// Create and initialize a store
+const store = createStore(INITIAL_STATE);
+
+// Watch for changes
+store.watch(console.log);
+
+// Change the color - this change will automatically call console.log in the next tick, producing
+// { roses: 'white', violets: 'blue' }
+store.edit((draft) => {
+  draft.roses = "white";
+});
+```
+
+Visit [@lauf/store-react](https://www.npmjs.com/package/@lauf/store-react) to learn about `useSelected()` which can refresh React components when only a selected part of your state changes.

--- a/modules/store-edit/esbuild.js
+++ b/modules/store-edit/esbuild.js
@@ -1,0 +1,3 @@
+const { doBuild } = require("../../esbuild.base.cjs");
+
+doBuild(__dirname);

--- a/modules/store-edit/jest.config.cjs
+++ b/modules/store-edit/jest.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  ...require("../../jest.config.base.cjs"),
+};

--- a/modules/store-edit/package.json
+++ b/modules/store-edit/package.json
@@ -1,6 +1,12 @@
 {
-  "name": "@lauf/lock",
+  "name": "@lauf/store-edit",
+  "description": "Intuitive mechanism to draft and write an edited @lauf/store state, (based on Immer)",
+  "private": true,
   "version": "1.1.1",
+  "files": [
+    "README.md",
+    "dist"
+  ],
   "license": "MIT",
   "scripts": {
     "test": "jest",
@@ -8,19 +14,19 @@
     "build": "rimraf dist && node ./esbuild.js && tsc --declaration --emitDeclarationOnly --outDir dist --project ./tsconfig.build.json",
     "prepublishOnly": "pnpm run test && pnpm run build"
   },
+  "dependencies": {
+    "@lauf/store": "^1.1.1",
+    "immer": "^9.0.15"
+  },
   "devDependencies": {
     "typescript": "^4.8.4"
   },
-  "files": [
-    "README.md",
-    "dist"
-  ],
   "publishConfig": {
     "access": "public",
     "main": "dist/index.js",
     "typings": "dist/index.d.ts"
   },
-  "homepage": "https://github.com/cefn/lauf/tree/main/modules/lock#readme",
+  "homepage": "https://github.com/cefn/lauf/tree/main/modules/store-edit#readme",
   "bugs": {
     "url": "https://github.com/cefn/lauf/issues",
     "email": "lauf@cefn.com"

--- a/modules/store-edit/src/edit.ts
+++ b/modules/store-edit/src/edit.ts
@@ -1,0 +1,20 @@
+import { Immutable, RootState, Store } from "@lauf/store";
+import produce from "immer";
+import { Editor } from "./types";
+
+/** Accepts an [[Editor]] function which will be passed a `draft` of the current
+ * state. The function can manipulate the draft state using normal javascript
+ * assignments and operations as if it ***wasn't*** [[Immutable]]. When it
+ * returns, [[write]] will be called on your behalf with the equivalent
+ * [[Immutable]] result.
+ * @param editor A function to draft the next state
+ * @returns The resulting new [[Immutable]] state aligned with your draft changes. */
+export function edit<State extends RootState>(
+  store: Store<State>,
+  editor: Editor<State>
+) {
+  const nextState = produce<State>(store.read() as State, (draft) => {
+    editor(draft);
+  }) as unknown as Immutable<State>;
+  return store.write(nextState);
+}

--- a/modules/store-edit/src/index.ts
+++ b/modules/store-edit/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./edit";
+export * from "./types";

--- a/modules/store-edit/src/types.ts
+++ b/modules/store-edit/src/types.ts
@@ -1,0 +1,32 @@
+/* eslint-disable @typescript-eslint/ban-types */
+import type { Draft } from "immer";
+
+/**  A function passed to [[edit]]. The editor is called back with a
+ * `draft` - a mutable proxy of the Store's current `Immutable` `RootState`.
+ *
+ * You can make changes to the mutable `draft` proxy within your editor callback
+ * using any javascript syntax. When it returns,
+ * {@link https://immerjs.github.io/immer/ | Immer} efficiently composes a new
+ * [[Immutable]] state to reflect your drafted changes, leaving the old state
+ * intact. The new state is passed to [[Store.write]].
+ *
+ * The editor is equivalent to Immer's producer except returning a value doesn't
+ * replace the [[RootState]]. To replace the state call [[Store.write]] instead
+ * of using an editor. This eliminates Immer's runtime errors when you **draft**
+ * changes as well as returning a value, (easily done by accident in simple
+ * arrow functions).
+ *
+ * For careful use in rare cases, Immer's `castDraft` is available in the second
+ * editor argument. It can cast parts of previous `Immutable` states to be
+ * 'mutable' for assignment to the next `draft` state. Thos items can be added
+ * to the draft state, but no changes should actually be made to them.
+ *
+ * See {@link https://immerjs.github.io/immer/ | Immer docs} for more detail on
+ * the conventions for Immer `producers`.
+ *
+ * @param draft A mutable proxy of a [[Store]]'s existing `Immutable` state,
+ * used to compose the next state.
+ * @param castDraft Unsafely casts `Immutable` references to mutable to use them
+ * in the next draft.
+ * */
+export type Editor<T> = (draft: Draft<T>) => void;

--- a/modules/store-edit/test/edit.test.ts
+++ b/modules/store-edit/test/edit.test.ts
@@ -1,0 +1,25 @@
+import { createStore } from "@lauf/store";
+import { edit } from "../src/edit";
+
+test("Editing replaces only ancestor objects containing a change", () => {
+  const store = createStore({
+    ancient: ["Roses are red", "Violets are blue"],
+    modern: ["Sugar is sweet", "So are you"],
+  });
+  const stateBefore = store.read();
+  edit(store, (draft) => {
+    draft.ancient[0] = "Roses are white";
+  });
+  const stateAfter = store.read();
+  expect(Object.is(stateBefore, stateAfter)).toBe(false);
+  expect(
+    [
+      stateBefore.ancient,
+      stateAfter.ancient,
+      stateBefore.ancient,
+      stateAfter.ancient,
+    ].every((item) => Array.isArray(item))
+  ).toBe(true);
+  expect(Object.is(stateBefore.ancient, stateAfter.ancient)).toBe(false);
+  expect(Object.is(stateBefore.modern, stateAfter.modern)).toBe(true);
+});

--- a/modules/store-edit/tsconfig.build.json
+++ b/modules/store-edit/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "outDir": "./dist"
+  }
+}

--- a/modules/store-edit/tsconfig.json
+++ b/modules/store-edit/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/modules/store-react/package.json
+++ b/modules/store-react/package.json
@@ -25,7 +25,6 @@
     "@testing-library/user-event": "^14.4.3",
     "typescript": "^4.8.4"
   },
-  "gitHead": "03bd2f443dd739f47240c303214f24d611aa4ddc",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.js",

--- a/modules/store/README.md
+++ b/modules/store/README.md
@@ -1,13 +1,13 @@
-## Lightweight Application State Management
+# Lightweight Application Update Framework
 
-[![codecov](https://codecov.io/gh/cefn/lauf/branch/main/graph/badge.svg?token=H4O0Wmvho5&flag=store)](https://codecov.io/gh/cefn/lauf)
+`@lauf/store` provides a minimal reactive state-management solution. It can replace Redux, MobX, Xstate, Unstated, Constate in your app in the most delightful way.
 
-<img src="https://github.com/cefn/lauf/raw/main/vector/logo.png" alt="Logo - Image of Runner" align="left"><br></br>
-
-# Lauf Store
+<img src="https://github.com/cefn/lauf/raw/main/vector/logo.png" alt="Logo - Image of Runner" ><br></br>
 
 <sub><sup>Logo - Diego Naive, Noun Project.</sup></sub>
 <br></br>
+
+[![codecov](https://codecov.io/gh/cefn/lauf/branch/main/graph/badge.svg?token=H4O0Wmvho5&flag=store)](https://codecov.io/gh/cefn/lauf)
 
 ### Install
 
@@ -15,36 +15,13 @@
 npm install @lauf/store --save
 ```
 
-`@lauf/store` provides a minimal reactive state-management solution, a simple substitute for Flux/Redux based on [Immer](https://immerjs.github.io/immer/).
+`@lauf/store` is incredibly lightweight and suitable for adoption with almost any server-side or client-side framework in Typescript or Javascript.
 
-It is incredibly lightweight and suitable for adoption with almost any server-side or client-side framework in Typescript or Javascript.
-
-Framework-independent async bindings for `@lauf/store` are provided by [@lauf/store-follow](https://www.npmjs.com/package/@lauf/store-follow).
-
-React bindings for `@lauf/store` are provided by [@lauf/store-react](https://www.npmjs.com/package/@lauf/store-react).
+- [Immutable Update patterns](https://redux.js.org/usage/structuring-reducers/immutable-update-patterns) are avoided with [@lauf/store-edit](https://www.npmjs.com/package/@lauf/store-edit) based on Immer.
+- Framework-independent bindings to track changes in `@lauf/store` are provided by [@lauf/store-follow](https://www.npmjs.com/package/@lauf/store-follow).
+- React bindings to track changes in `@lauf/store` are provided by [@lauf/store-react](https://www.npmjs.com/package/@lauf/store-react).
 
 Browse the [API](https://cefn.com/lauf/api/modules/_lauf_store.html) or see the minimal JS and TS examples inlined below **_without_** React or Async, showing the fundamentals of defining a new application state, tracking changes and making edits.
-
-### In Javascript
-
-```javascript
-const { createStore } = require("@lauf/store");
-
-// Create and initialize a store
-const store = createStore({
-  roses: "red",
-  violets: "blue",
-});
-
-// Watch for changes
-store.watch(console.log);
-
-// Change the color - this change will automatically call console.log in the next tick, producing
-// { roses: 'white', violets: 'blue' }
-store.edit((draft) => {
-  draft.roses = "white";
-});
-```
 
 ### In Typescript
 
@@ -68,9 +45,40 @@ store.watch(console.log);
 
 // Change the color - this change will automatically call console.log in the next tick, producing
 // { roses: 'white', violets: 'blue' }
-store.edit((draft) => {
-  draft.roses = "white";
+store.write({
+  ...store.read(),
+  roses: "white",
 });
 ```
+
+Because Store is defined as having an Immutable state, Typescript editors will automatically warn you if you fail to correctly follow [Immutable Update patterns](https://redux.js.org/usage/structuring-reducers/immutable-update-patterns).
+
+### In Javascript
+
+```javascript
+const { createStore } = require("@lauf/store");
+
+// Create and initialize a store
+const store = createStore({
+  roses: "red",
+  violets: "blue",
+});
+
+// Watch for changes
+store.watch(console.log);
+
+// Change the color - this change will automatically call console.log in the next tick, producing
+// { roses: 'white', violets: 'blue' }
+store.write({
+  ...store.read(),
+  roses: "white",
+});
+```
+
+It is recommended for Javascript coders to use [@lauf/store-edit](https://www.npmjs.com/package/@lauf/store-edit) since their editor may not assist them in following [Immutable Update patterns](https://redux.js.org/usage/structuring-reducers/immutable-update-patterns).
+
+## Editors and Selectors
+
+Visit [@lauf/store-edit](https://www.npmjs.com/package/@lauf/store-edit) to learn about `edit()` which eliminates the need to use [Immutable Update patterns](https://redux.js.org/usage/structuring-reducers/immutable-update-patterns).
 
 Visit [@lauf/store-react](https://www.npmjs.com/package/@lauf/store-react) to learn about `useSelected()` which can refresh React components when only a selected part of your state changes.

--- a/modules/store/package.json
+++ b/modules/store/package.json
@@ -13,13 +13,9 @@
     "build": "rimraf dist && node ./esbuild.js && tsc --declaration --emitDeclarationOnly --outDir dist --project ./tsconfig.build.json",
     "prepublishOnly": "pnpm run test && pnpm run build"
   },
-  "dependencies": {
-    "immer": "^9.0.15"
-  },
   "devDependencies": {
     "typescript": "^4.8.4"
   },
-  "gitHead": "03bd2f443dd739f47240c303214f24d611aa4ddc",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.js",

--- a/modules/store/src/core/index.ts
+++ b/modules/store/src/core/index.ts
@@ -1,2 +1,3 @@
 export { createStore } from "./store";
 export { createStorePartition } from "./partition";
+export { DefaultWatchableState } from "./watchableState";

--- a/modules/store/src/core/partition.ts
+++ b/modules/store/src/core/partition.ts
@@ -1,6 +1,4 @@
-import { castDraft, Draft } from "immer";
 import {
-  Editor,
   Immutable,
   PartitionableState,
   Selector,
@@ -52,13 +50,6 @@ class DefaultStorePartition<
       [this.key]: state,
     });
     return state;
-  };
-
-  edit = (editor: Editor<ParentState[Key]>) => {
-    this.store.edit((draft, toDraft) => {
-      editor((draft as any)[this.key], toDraft);
-    });
-    return this.read();
   };
 
   select = <Selected>(selector: Selector<ParentState[Key], Selected>) => {

--- a/modules/store/src/core/store.ts
+++ b/modules/store/src/core/store.ts
@@ -1,24 +1,11 @@
-import { castDraft, produce } from "immer";
-import type { RootState, Selector, Store, Watcher } from "../types";
-import type { Editor, Immutable } from "../types/immutable";
+import type { RootState, Store, Watcher } from "../types";
+import type { Immutable } from "../types/immutable";
 import { DefaultWatchableState } from "./watchableState";
 
 /** Reference implementation of Lauf [[Store]]  */
 class DefaultStore<State extends RootState>
   extends DefaultWatchableState<Immutable<State>>
-  implements Store<State>
-{
-  edit = (editor: Editor<State>) => {
-    const nextState = produce<Immutable<State>>(this.read(), (draft) => {
-      editor(draft, castDraft);
-    }) as unknown as Immutable<State>;
-    return this.write(nextState);
-  };
-
-  select = <Selected>(selector: Selector<State, Selected>) => {
-    return selector(this.read());
-  };
-}
+  implements Store<State> {}
 
 /** Initialise a [[Store]] with an [[Immutable]] initial [[RootState]] - any
  * array, tuple or object. This state can be updated and monitored for updates

--- a/modules/store/src/types/immutable.ts
+++ b/modules/store/src/types/immutable.ts
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-types */
-import type { castDraft, Draft } from "immer";
-
 /** Recursive implementation of Typescript's `Readonly<T>`.
  *
  * Unlike some implementations of immutability this approach introduces no
@@ -33,43 +30,6 @@ export type Immutable<T> = T extends (...args: any[]) => any
 
 /** Recursive Readonly implementation for any (indexable) [[RootState]] such as
  * an array or object */
-type ImmutableIndex<T> = Readonly<
-  {
-    [K in keyof T]: Immutable<T[K]>;
-  }
->;
-
-type CastDraft = typeof castDraft;
-
-/**  A function passed to [[Store.edit]]. The editor is called back with a
- * `draft` - a mutable proxy of the Store's current `Immutable` `RootState`.
- *
- * You can make changes to the mutable `draft` proxy within your editor callback
- * using any javascript syntax. When it returns,
- * {@link https://immerjs.github.io/immer/ | Immer} efficiently composes a new
- * [[Immutable]] state to reflect your drafted changes, leaving the old state
- * intact. The new state is passed to [[Store.write]].
- *
- * The editor is equivalent to Immer's producer except returning a value doesn't
- * replace the [[RootState]]. To replace the state call [[Store.write]] instead
- * of using an editor. This eliminates Immer's runtime errors when you **draft**
- * changes as well as returning a value, (easily done by accident in simple
- * arrow functions).
- *
- * For careful use in rare cases, Immer's `castDraft` is available in the second
- * editor argument. It can cast parts of previous `Immutable` states to be
- * 'mutable' for assignment to the next `draft` state. Thos items can be added
- * to the draft state, but no changes should actually be made to them.
- *
- * See {@link https://immerjs.github.io/immer/ | Immer docs} for more detail on
- * the conventions for Immer `producers`.
- *
- * @param draft A mutable proxy of a [[Store]]'s existing `Immutable` state,
- * used to compose the next state.
- * @param castDraft Unsafely casts `Immutable` references to mutable to use them
- * in the next draft.
- * */
-export type Editor<T> = (
-  draft: Draft<Immutable<T>>,
-  castDraft: CastDraft
-) => void;
+type ImmutableIndex<T> = Readonly<{
+  [K in keyof T]: Immutable<T[K]>;
+}>;

--- a/modules/store/src/types/store.ts
+++ b/modules/store/src/types/store.ts
@@ -1,27 +1,19 @@
-/* eslint-disable @typescript-eslint/ban-types */
-import type { Immutable, Editor } from "./immutable";
+import { Immutable } from "./immutable";
 import { WatchableState } from "./watchable";
 
 /** A `Store` keeps an Immutable [[RootState]] - any array, tuple or object -
  * which can be changed and monitored for changes to drive an app. Make a new
  * `Store` by calling [[createStore]] with an `initialState`.
  *
+ * Flagging all state references as [[Immutable]] guides IDEs to treat these as
+ * [Immutable Objects]{@link https://en.wikipedia.org/wiki/Immutable_object} to
+ * avoid programming errors.
+ *
  * ## Watching State
  *
  * Assigning a new [[Immutable]] `RootState` using [[Store.write]] notifies
  * [[Watcher|Watchers]] previously subscribed using [[Store.watch]]. This
  * mechanism ensures that app logic and renderers can track the latest state.
- *
- * ## Editing State
- *
- * Changes to state are normally 'drafted' by calling [[Store.edit]] and passing
- * an editor callback function. In this function you can make changes to state
- * as if it ***wasn't*** [[Immutable]], then [[write]] will be called on your
- * behalf with the equivalent [[Immutable]] result. See [[Editor]] for more
- * about drafting.
- *
- * Alternatively you can construct a new `Immutable` value yourself, then
- * explicitly call [[Store.write]] to update the state.
  *
  * ## Immutable State: Motivation
  *
@@ -47,41 +39,19 @@ import { WatchableState } from "./watchable";
  * such as time-travel debugging since every state change notification includes
  * a momentary snapshot of the app state which can be stored indefinitely.
  *
- * *Note whenever you [[Editor|edit]] data in the Store, this necessarily
- * operates over the current, not historical state, but this reconciliation is
- * unavoidable and manageable.*
- *
  */
 export interface Store<State extends RootState>
-  extends WatchableState<Immutable<State>> {
-  /** Accepts an [[Editor]] function which will be passed a `draft` of the
-   * current state. The function can manipulate the draft state using normal
-   * javascript assignments and operations. When it returns, a new Immutable
-   * state is passed to [[write]] which matches those changes.
-   * @param editor A function to draft the next state
-   * @returns The resulting new [[Immutable]] state. */
-  edit: (editor: Editor<State>) => Immutable<State>;
-
-  /** Derive some sub-part or computed value from the current state using a
-   * [[Selector]]. A bound method for convenience that is equivalent to
-   * `selector(store.read())`.
-   * @param selector A [[Selector]] which will be passed the current state.
-   * @returns The value extracted or computed by the selector.
-   */
-  select: <Selected>(
-    selector: Selector<State, Selected>
-  ) => Immutable<Selected>;
-}
-
-/** Function deriving some sub-part or computed value from a [[RootState]]. */
-export type Selector<State extends RootState, Selected> = (
-  state: Immutable<State>
-) => Immutable<Selected>;
+  extends WatchableState<Immutable<State>> {}
 
 /** Defines the set of possible state types for a [[Store]],
  * usually the top level State 'container' is either an
  * Array, Tuple, or keyed Object */
 export type RootState = object;
+
+/** Function deriving some sub-part or computed value from a [[RootState]]. */
+export type Selector<State extends RootState, Selected> = (
+  state: Immutable<State>
+) => Immutable<Selected>;
 
 /** An item satisfying type constraints of [[RootState]] but where a child item
  * at `Key` ***also*** satisfies `RootState`. A Store with a

--- a/modules/store/test/core/partition.test.ts
+++ b/modules/store/test/core/partition.test.ts
@@ -5,8 +5,8 @@ import {
   RootState,
   Watcher,
 } from "@lauf/store";
-import { createDeferredMock } from "../util";
-import { createStoreSuite, StoreFactory } from "./storeSuite";
+import { createStoreSuite, StoreFactory } from "../storeSuite";
+import { createDeferred } from "../util";
 
 /** TEST PARTITIONS AS A GENERAL STORE */
 
@@ -67,7 +67,7 @@ describe("Parent Stores and Child Store Partitions", () => {
     };
   }
   test("Child watchers notified of parent store assignments inside partition", async () => {
-    const { deferred, deferredResolve } = createDeferredMock<ChildState>();
+    const { deferred, deferredResolve } = createDeferred<ChildState>();
     const { parentStore, childStore } = createPartitionedStores();
     childStore.watch(deferredResolve);
     // set a deep value
@@ -100,7 +100,7 @@ describe("Parent Stores and Child Store Partitions", () => {
   });
 
   test("Parent watchers notified of child store assignments inside partition", async () => {
-    const { deferred, deferredResolve } = createDeferredMock<ParentState>();
+    const { deferred, deferredResolve } = createDeferred<ParentState>();
     const { parentStore, childStore } = createPartitionedStores();
     parentStore.watch(deferredResolve);
     // set a deep value
@@ -113,17 +113,15 @@ describe("Parent Stores and Child Store Partitions", () => {
   });
 
   test("Parent watchers notified if child store overwrites partition", async () => {
-    const { deferred, deferredResolve } = createDeferredMock<ParentState>();
+    const { deferred, deferredResolve } = createDeferred<ParentState>();
     const { parentStore, childStore } = createPartitionedStores();
     parentStore.watch(deferredResolve);
     childStore.write({ roses: "white" });
     expect(await deferred).toBe(parentStore.read());
   });
 
-  test("Child select and Parent select results correspond", () => {
+  test("Child path and Parent path results correspond", () => {
     const { parentStore, childStore } = createPartitionedStores();
-    expect(childStore.select((state) => state.roses)).toBe(
-      parentStore.select((state) => state.partition.roses)
-    );
+    expect(childStore.read().roses).toBe(parentStore.read().partition.roses);
   });
 });

--- a/modules/store/test/core/store.test.ts
+++ b/modules/store/test/core/store.test.ts
@@ -1,5 +1,5 @@
 import { createStore, Immutable, RootState, Watcher } from "@lauf/store";
-import { StoreFactory, createStoreSuite } from "./storeSuite";
+import { createStoreSuite, StoreFactory } from "../storeSuite";
 
 const rootStoreFactory: StoreFactory = <State extends RootState>(
   state: Immutable<State>,

--- a/modules/store/test/util.ts
+++ b/modules/store/test/util.ts
@@ -1,12 +1,15 @@
-export function createDeferredMock<Result>() {
+/** Simple implementation of a 'deferred' Promise value, which
+ * defines a useful callback for explicitly resolving the Promise
+ */
+export function createDeferred<Result>() {
   type Resolve = (result: Result) => void;
-  let deferredResolve: Resolve | null = null;
+  let deferredResolve: Resolve;
   const deferred = new Promise<Result>((resolve) => {
     deferredResolve = resolve;
   });
   return {
     // tell compiler about IIFE assignment ( https://github.com/microsoft/TypeScript/issues/11498 )
-    deferredResolve: (deferredResolve as unknown) as Resolve,
+    deferredResolve: deferredResolve!,
     deferred,
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,9 +338,17 @@ importers:
 
   modules/store:
     specifiers:
+      typescript: ^4.8.4
+    devDependencies:
+      typescript: 4.8.4
+
+  modules/store-edit:
+    specifiers:
+      '@lauf/store': ^1.1.1
       immer: ^9.0.15
       typescript: ^4.8.4
     dependencies:
+      '@lauf/store': link:../store
       immer: 9.0.15
     devDependencies:
       typescript: 4.8.4


### PR DESCRIPTION
Removes the `store.edit()` and `store.select()` methods, simplifying the definition of Store and allowing the removal of Immer.

Immer is the vast majority of the [size of @lauf/store in bundlephobia](https://bundlephobia.com/package/@lauf/store). It also makes it harder to explain the simplicity and minimalism of @lauf/store.